### PR TITLE
Fix: parent state waiting changed when shouldn't

### DIFF
--- a/packages/uif/src/indexerReducer.test.ts
+++ b/packages/uif/src/indexerReducer.test.ts
@@ -373,6 +373,34 @@ describe(indexerReducer.name, () => {
         ])
       })
     })
+
+    describe('complex scenario', () => {
+      it('if parent is waiting, it keeps waiting until notifyReady', () => {
+        //1. grandparent ticks lower (to: x1) && parent updating (to: x2)-> parent sets (safeHeight: x1), but still updating (to:x2), child sets (safeHeight: x1) -> parennt finishes update (to: x2, waiting: true), child notifies ready
+        const initState = getAfterInit({
+          safeHeight: 100,
+          childCount: 1,
+          parentHeights: [100],
+        })
+
+        const [state, effects] = reduceWithIndexerReducer(initState, [
+          { type: 'ParentUpdated', index: 0, safeHeight: 50 },
+          { type: 'ParentUpdated', index: 0, safeHeight: 50 },
+        ])
+
+        expect(state).toEqual({
+          ...initState,
+          status: 'idle',
+          targetHeight: 50,
+          safeHeight: 50,
+          waiting: true,
+          parents: [{ safeHeight: 50, initialized: true, waiting: true }],
+          children: [{ ready: false }],
+        })
+
+        expect(effects).toEqual([])
+      })
+    })
   })
 })
 

--- a/packages/uif/src/indexerReducer.ts
+++ b/packages/uif/src/indexerReducer.ts
@@ -30,18 +30,19 @@ export function indexerReducer(
     case 'ParentUpdated': {
       const newState: IndexerState = {
         ...state,
-        parents: state.parents.map((parent, index) =>
-          index === action.index
-            ? {
-                ...parent,
-                safeHeight: action.safeHeight,
-                initialized: true,
-                waiting: parent.initialized
-                  ? action.safeHeight < parent.safeHeight
-                  : false,
-              }
-            : parent,
-        ),
+        parents: state.parents.map((parent, index) => {
+          if (index === action.index) {
+            const waiting =
+              parent.waiting || action.safeHeight < parent.safeHeight
+            return {
+              ...parent,
+              safeHeight: action.safeHeight,
+              initialized: true,
+              waiting: parent.initialized ? waiting : false,
+            }
+          }
+          return parent
+        }),
       }
 
       const result = finishInitialization(newState)


### PR DESCRIPTION
This was a problem in indexReducer. 

Grandparent -> parent -> child
1. Grandparent invalidated, but parent was updating. 
2. Parent and child changed safeHeight to the grandparent's safeHeight.
3. Parent finished updating, so `ParentUpdated` action was triggered in a child, but this time with the same safeHeight as before, so the parent's field in children's state was updated to `waiting: false`

This PR fixes this issue by making sure that `ParentUpdated` action does not change the `waiting` field to false. It will only happen if `NotifyReady` effect is emmited. 