### PR TITLE
Add TVL indexer to the example package

### DIFF
--- a/packages/example/src/Application.ts
+++ b/packages/example/src/Application.ts
@@ -6,6 +6,8 @@ import { BlockNumberIndexer } from './indexers/BlockNumberIndexer'
 import { FakeClockIndexer } from './indexers/FakeClockIndexer'
 import { BalanceRepository } from './repositories/BalanceRepository'
 import { BlockNumberRepository } from './repositories/BlockNumberRepository'
+import { TvlRepository } from './repositories/TvlRepository'
+import { TvlIndexer } from './indexers/TvlIndexer'
 
 export class Application {
   start: () => Promise<void>
@@ -20,6 +22,7 @@ export class Application {
 
     const blockNumberRepository = new BlockNumberRepository()
     const balanceRepository = new BalanceRepository()
+    const tvlRepository = new TvlRepository()
 
     const fakeClockIndexer = new FakeClockIndexer(logger)
     const blockNumberIndexer = new BlockNumberIndexer(
@@ -32,6 +35,11 @@ export class Application {
       blockNumberIndexer,
       balanceRepository,
     )
+    const tvlIndexer = new TvlIndexer(
+      logger,
+      balanceIndexer,
+      tvlRepository,
+    )
 
     this.start = async (): Promise<void> => {
       await Promise.resolve()
@@ -40,6 +48,7 @@ export class Application {
       await fakeClockIndexer.start()
       await blockNumberIndexer.start()
       await balanceIndexer.start()
+      await tvlIndexer.start()
     }
   }
 }

--- a/packages/example/src/indexers/BalanceIndexer.ts
+++ b/packages/example/src/indexers/BalanceIndexer.ts
@@ -17,7 +17,11 @@ export class BalanceIndexer extends ChildIndexer {
 
   override async update(from: number, to: number): Promise<number> {
     this.logger.info('Update started')
-    await setTimeout(2_000)
+    await setTimeout(1_000)
+    if(Math.random() < 0.1) {
+      this.logger.info('BalanceIndexer: height decreased')
+      return Math.max(from - 5, 0)
+    }
     to = Math.min(from + 5, to)
     return to
   }

--- a/packages/example/src/indexers/FakeClockIndexer.ts
+++ b/packages/example/src/indexers/FakeClockIndexer.ts
@@ -10,7 +10,7 @@ export class FakeClockIndexer extends RootIndexer {
 
   override async start(): Promise<void> {
     await super.start()
-    setInterval(() => this.scheduleTick(), 1000)
+    setInterval(() => this.scheduleTick(), 1_000)
   }
 
   override async tick(): Promise<number> {

--- a/packages/example/src/indexers/TvlIndexer.ts
+++ b/packages/example/src/indexers/TvlIndexer.ts
@@ -1,0 +1,36 @@
+import { Logger } from '@l2beat/backend-tools'
+import { ChildIndexer } from '@l2beat/uif'
+import { setTimeout } from 'timers/promises'
+import { BalanceIndexer } from './BalanceIndexer'
+import { TvlRepository } from '../repositories/TvlRepository'
+
+export class TvlIndexer extends ChildIndexer {
+  constructor(
+    logger: Logger,
+    balanceIndexer: BalanceIndexer,
+    private readonly tvlRepository: TvlRepository,
+  ) {
+    super(logger, [balanceIndexer])
+  }
+
+  override async update(from: number, to: number) {
+    this.logger.info('Update started')
+    await setTimeout(2_000)
+    to = Math.min(from + 10, to)
+    return to
+  }
+
+  override async invalidate() {
+    this.logger.info('Invalidate started')
+    return Promise.resolve()
+  }
+
+  override async getSafeHeight() {
+    const height = await this.tvlRepository.getLastSynced()
+    return height ?? 0
+  }
+
+  override async setSafeHeight(height: number): Promise<void> {
+    await this.tvlRepository.setLastSynced(height)
+  }
+}

--- a/packages/example/src/repositories/TvlRepository.ts
+++ b/packages/example/src/repositories/TvlRepository.ts
@@ -1,0 +1,12 @@
+export class TvlRepository {
+  private lastSynced: number | undefined = undefined
+
+  async getLastSynced(): Promise<number | undefined> {
+    return Promise.resolve(this.lastSynced)
+  }
+
+  async setLastSynced(lastSynced: number): Promise<void> {
+    this.lastSynced = lastSynced
+    return Promise.resolve()
+  }
+}


### PR DESCRIPTION
This allows adding more complexity to the example pipeline and validates the idea of self-invalidation inside the indexer (BalanceIndexer can now decide it wants to invalidate).