### PR TITLE
Enable slice invalidation

### DIFF
--- a/.changeset/dry-maps-exercise.md
+++ b/.changeset/dry-maps-exercise.md
@@ -1,0 +1,5 @@
+---
+'@l2beat/uif': minor
+---
+
+Add SliceIndexer

--- a/packages/example/src/Application.ts
+++ b/packages/example/src/Application.ts
@@ -2,10 +2,14 @@ import { Logger } from '@l2beat/backend-tools'
 
 import { BaseIndexer, Retries } from '@l2beat/uif'
 import { Config } from './Config'
+import { ABC_Indexer } from './indexers/ABC_Indexer'
+import { AB_BC_Indexer } from './indexers/AB_BC_Indexer'
 import { BalanceIndexer } from './indexers/BalanceIndexer'
 import { BlockNumberIndexer } from './indexers/BlockNumberIndexer'
 import { FakeClockIndexer } from './indexers/FakeClockIndexer'
 import { TvlIndexer } from './indexers/TvlIndexer'
+import { ABC_Repository } from './repositories/ABC_Repository'
+import { AB_BC_Repository } from './repositories/AB_BC_Repository'
 import { BalanceRepository } from './repositories/BalanceRepository'
 import { BlockNumberRepository } from './repositories/BlockNumberRepository'
 import { TvlRepository } from './repositories/TvlRepository'
@@ -21,37 +25,96 @@ export class Application {
       utc: true,
     })
 
-    const blockNumberRepository = new BlockNumberRepository()
-    const balanceRepository = new BalanceRepository()
-    const tvlRepository = new TvlRepository()
-
-    BaseIndexer.DEFAULT_RETRY_STRATEGY = Retries.exponentialBackOff({
-      initialTimeoutMs: 100,
-      maxAttempts: 10,
-      maxTimeoutMs: 60 * 1000,
-    })
-
-    const fakeClockIndexer = new FakeClockIndexer(logger)
-    const blockNumberIndexer = new BlockNumberIndexer(
-      logger,
-      fakeClockIndexer,
-      blockNumberRepository,
-    )
-    const balanceIndexer = new BalanceIndexer(
-      logger,
-      blockNumberIndexer,
-      balanceRepository,
-    )
-    const tvlIndexer = new TvlIndexer(logger, balanceIndexer, tvlRepository)
+    const modules = [
+      createMainModule(config, logger),
+      createABCModule(config, logger),
+    ]
 
     this.start = async (): Promise<void> => {
-      await Promise.resolve()
       console.log(`Application started: ${config.name}`)
+      await Promise.all(modules.map((module) => module && module.start()))
+    }
+  }
+}
+
+function createABCModule(config: Config, logger: Logger) {
+  if (!config.modules.abc) {
+    return undefined
+  }
+
+  const blockNumberRepository = new BlockNumberRepository()
+  const abc_repository = new ABC_Repository()
+  const ab_bc_repository = new AB_BC_Repository()
+
+  const fakeClockIndexer = new FakeClockIndexer(
+    logger.configure({ logLevel: 'NONE' }),
+  )
+  const blockNumberIndexer = new BlockNumberIndexer(
+    logger.configure({ logLevel: 'NONE' }),
+    fakeClockIndexer,
+    blockNumberRepository,
+  )
+  const abc_Indexer = new ABC_Indexer(
+    logger,
+    blockNumberIndexer,
+    abc_repository,
+  )
+  const ab_bc_indexer = new AB_BC_Indexer(
+    logger,
+    abc_Indexer,
+    ab_bc_repository,
+    abc_repository,
+  )
+
+  return {
+    start: async (): Promise<void> => {
+      console.log(`Module started: ABCModule`)
+
+      await fakeClockIndexer.start()
+      await blockNumberIndexer.start()
+      await abc_Indexer.start()
+      await ab_bc_indexer.start()
+    },
+  }
+}
+
+function createMainModule(config: Config, logger: Logger) {
+  if (!config.modules.main) {
+    return undefined
+  }
+
+  const blockNumberRepository = new BlockNumberRepository()
+  const balanceRepository = new BalanceRepository()
+  const tvlRepository = new TvlRepository()
+
+  BaseIndexer.DEFAULT_RETRY_STRATEGY = Retries.exponentialBackOff({
+    initialTimeoutMs: 100,
+    maxAttempts: 10,
+    maxTimeoutMs: 60 * 1000,
+  })
+
+  const fakeClockIndexer = new FakeClockIndexer(logger)
+  const blockNumberIndexer = new BlockNumberIndexer(
+    logger,
+    fakeClockIndexer,
+    blockNumberRepository,
+  )
+  const balanceIndexer = new BalanceIndexer(
+    logger,
+    blockNumberIndexer,
+    balanceRepository,
+  )
+  const tvlIndexer = new TvlIndexer(logger, balanceIndexer, tvlRepository)
+
+  return {
+    start: async (): Promise<void> => {
+      await Promise.resolve()
+      console.log(`Application started: MainModule`)
 
       await fakeClockIndexer.start()
       await blockNumberIndexer.start()
       await balanceIndexer.start()
       await tvlIndexer.start()
-    }
+    },
   }
 }

--- a/packages/example/src/Config.ts
+++ b/packages/example/src/Config.ts
@@ -1,9 +1,17 @@
 export interface Config {
   name: string
+  modules: {
+    main: boolean
+    abc: boolean
+  }
 }
 
 export function getConfig(): Config {
   return {
     name: 'uif-example',
+    modules: {
+      main: false,
+      abc: true,
+    },
   }
 }

--- a/packages/example/src/indexers/ABC_Indexer.ts
+++ b/packages/example/src/indexers/ABC_Indexer.ts
@@ -1,0 +1,64 @@
+import { Logger } from '@l2beat/backend-tools'
+import { SliceIndexer, SliceState, SliceUpdate } from '@l2beat/uif'
+import { ABC_Repository } from '../repositories/ABC_Repository'
+import { BlockNumberIndexer } from './BlockNumberIndexer'
+
+export class ABC_Indexer extends SliceIndexer {
+  constructor(
+    logger: Logger,
+    blockNumberIndexer: BlockNumberIndexer,
+    private abc_repository: ABC_Repository,
+    private tokens = ['A', 'B', 'C'],
+  ) {
+    super(logger, [blockNumberIndexer])
+  }
+
+  override getExpectedSlices(): string[] {
+    return this.tokens
+  }
+
+  override async getSliceState(): Promise<SliceState[]> {
+    const tokenHeights = await this.abc_repository.getSliceHeights()
+    const states = [...tokenHeights.entries()].map(
+      ([token, height]): SliceState => ({
+        sliceHash: token,
+        height,
+      }),
+    )
+    return states
+  }
+
+  override async removeSlices(hashes: string[]): Promise<void> {
+    return await this.abc_repository.removeSlices(hashes)
+  }
+
+  override async updateSlices(updates: SliceUpdate[]): Promise<number> {
+    let minHeight = Infinity
+    for (const update of updates) {
+      const balances = await this.abc_repository.getSliceData(update.sliceHash)
+
+      for (let i = update.from; i <= update.to; i++) {
+        balances.set(i, i * 2)
+      }
+      if (update.to < minHeight) {
+        minHeight = update.to
+      }
+
+      await this.abc_repository.setSliceData(update.sliceHash, balances)
+      await this.abc_repository.setSliceHeight(update.sliceHash, update.to)
+    }
+    return minHeight
+  }
+
+  override async getMainSafeHeight(): Promise<number> {
+    return await this.abc_repository.getSafeHeight()
+  }
+
+  override async setMainSafeHeight(height: number): Promise<void> {
+    await this.abc_repository.setSafeHeight(height)
+  }
+
+  override invalidate(targetHeight: number): Promise<number> {
+    return Promise.resolve(targetHeight)
+  }
+}

--- a/packages/example/src/indexers/ABC_Indexer.ts
+++ b/packages/example/src/indexers/ABC_Indexer.ts
@@ -17,7 +17,7 @@ export class ABC_Indexer extends SliceIndexer {
     return this.tokens
   }
 
-  override async getSliceState(): Promise<SliceState[]> {
+  override async getSliceStates(): Promise<SliceState[]> {
     const tokenHeights = await this.abc_repository.getSliceHeights()
     const states = [...tokenHeights.entries()].map(
       ([token, height]): SliceState => ({

--- a/packages/example/src/indexers/AB_BC_Indexer.ts
+++ b/packages/example/src/indexers/AB_BC_Indexer.ts
@@ -27,7 +27,7 @@ export class AB_BC_Indexer extends SliceIndexer {
     return [...this.slices.keys()]
   }
 
-  override async getSliceState(): Promise<SliceState[]> {
+  override async getSliceStates(): Promise<SliceState[]> {
     const sliceHeights = await this.ab_bc_repository.getSliceHeights()
     const states = [...sliceHeights.entries()].map(
       ([sliceHash, height]): SliceState => ({ sliceHash, height }),

--- a/packages/example/src/indexers/AB_BC_Indexer.ts
+++ b/packages/example/src/indexers/AB_BC_Indexer.ts
@@ -1,0 +1,78 @@
+import { Logger } from '@l2beat/backend-tools'
+import { SliceIndexer, SliceState, SliceUpdate } from '@l2beat/uif'
+import { ABC_Repository } from '../repositories/ABC_Repository'
+import { AB_BC_Repository } from '../repositories/AB_BC_Repository'
+import { ABC_Indexer } from './ABC_Indexer'
+
+export class AB_BC_Indexer extends SliceIndexer {
+  private slices = new Map<string, string[]>()
+
+  constructor(
+    logger: Logger,
+    abc_indexer: ABC_Indexer,
+    private ab_bc_repository: AB_BC_Repository,
+    private abc_repository: ABC_Repository,
+    private sums = [
+      ['A', 'B'],
+      ['B', 'C'],
+    ],
+  ) {
+    super(logger, [abc_indexer])
+    this.slices = new Map<string, string[]>(
+      this.sums.map((sum) => [sum.join('+'), sum]),
+    )
+  }
+
+  override getExpectedSlices(): string[] {
+    return [...this.slices.keys()]
+  }
+
+  override async getSliceState(): Promise<SliceState[]> {
+    const sliceHeights = await this.ab_bc_repository.getSliceHeights()
+    const states = [...sliceHeights.entries()].map(
+      ([sliceHash, height]): SliceState => ({ sliceHash, height }),
+    )
+    return Promise.resolve(states)
+  }
+
+  override async removeSlices(hashes: string[]): Promise<void> {
+    await this.ab_bc_repository.removeSlices(hashes)
+  }
+
+  override async updateSlices(updates: SliceUpdate[]): Promise<number> {
+    let minHeight = Infinity
+    for (const update of updates) {
+      const sumMap = await this.ab_bc_repository.getSliceData(update.sliceHash)
+
+      for (let i = update.from; i <= update.to; i++) {
+        const tokens = this.slices.get(update.sliceHash) ?? []
+        const values = await Promise.all(
+          tokens.map((token) => this.abc_repository.getTokenBalance(token, i)),
+        )
+        sumMap.set(
+          i,
+          values.reduce((a, b) => a + b, 0),
+        )
+      }
+      if (update.to < minHeight) {
+        minHeight = update.to
+      }
+
+      await this.ab_bc_repository.setSliceData(update.sliceHash, sumMap)
+      await this.ab_bc_repository.setSliceHeight(update.sliceHash, update.to)
+    }
+    return Promise.resolve(minHeight)
+  }
+
+  override async getMainSafeHeight(): Promise<number> {
+    return await this.ab_bc_repository.getSafeHeight()
+  }
+
+  override async setMainSafeHeight(height: number): Promise<void> {
+    await this.ab_bc_repository.setSafeHeight(height)
+  }
+
+  override async invalidate(targetHeight: number): Promise<number> {
+    return Promise.resolve(targetHeight)
+  }
+}

--- a/packages/example/src/repositories/ABC_Repository.ts
+++ b/packages/example/src/repositories/ABC_Repository.ts
@@ -1,0 +1,43 @@
+export class ABC_Repository {
+  private sliceHeights = new Map<string, number>()
+  private sliceData = new Map<string, Map<number, number>>()
+  private safeHeight = 0
+
+  async getSliceHeights() {
+    return Promise.resolve(this.sliceHeights)
+  }
+  async getSliceData(hash: string) {
+    const sliceData = this.sliceData.get(hash) ?? new Map<number, number>()
+    return Promise.resolve(sliceData)
+  }
+  async removeSlices(hashes: string[]) {
+    Promise.resolve()
+    for (const hash of hashes) {
+      this.sliceHeights.delete(hash)
+      this.sliceData.delete(hash)
+    }
+  }
+  async setSliceHeight(hash: string, height: number) {
+    Promise.resolve()
+    this.sliceHeights.set(hash, height)
+  }
+  async setSliceData(hash: string, data: Map<number, number>) {
+    Promise.resolve()
+    this.sliceData.set(hash, data)
+  }
+  async getSafeHeight() {
+    return Promise.resolve(this.safeHeight)
+  }
+  async setSafeHeight(height: number) {
+    Promise.resolve()
+    this.safeHeight = height
+  }
+
+  async getTokenBalance(token: string, blockNumber: number) {
+    const balance = this.sliceData.get(token)?.get(blockNumber)
+    if (balance === undefined) {
+      throw new Error(`No balance of ${token} for ${blockNumber}`)
+    }
+    return Promise.resolve(balance)
+  }
+}

--- a/packages/example/src/repositories/AB_BC_Repository.ts
+++ b/packages/example/src/repositories/AB_BC_Repository.ts
@@ -1,0 +1,35 @@
+export class AB_BC_Repository {
+  private sliceHeights = new Map<string, number>()
+  private sliceData = new Map<string, Map<number, number>>()
+  private safeHeight = 0
+
+  async getSliceHeights() {
+    return Promise.resolve(this.sliceHeights)
+  }
+  async getSliceData(hash: string) {
+    const sliceData = this.sliceData.get(hash) ?? new Map<number, number>()
+    return Promise.resolve(sliceData)
+  }
+  async removeSlices(hashes: string[]) {
+    Promise.resolve()
+    for (const hash of hashes) {
+      this.sliceHeights.delete(hash)
+      this.sliceData.delete(hash)
+    }
+  }
+  async setSliceHeight(hash: string, height: number) {
+    Promise.resolve()
+    this.sliceHeights.set(hash, height)
+  }
+  async setSliceData(hash: string, data: Map<number, number>) {
+    Promise.resolve()
+    this.sliceData.set(hash, data)
+  }
+  async getSafeHeight() {
+    return Promise.resolve(this.safeHeight)
+  }
+  async setSafeHeight(height: number) {
+    Promise.resolve()
+    this.safeHeight = height
+  }
+}

--- a/packages/uif/src/BaseIndexer.test.ts
+++ b/packages/uif/src/BaseIndexer.test.ts
@@ -214,7 +214,7 @@ describe(BaseIndexer.name, () => {
   })
 })
 
-async function waitUntil(predicate: () => boolean): Promise<void> {
+export async function waitUntil(predicate: () => boolean): Promise<void> {
   return new Promise<void>((resolve) => {
     const interval = setInterval(() => {
       if (predicate()) {
@@ -225,7 +225,7 @@ async function waitUntil(predicate: () => boolean): Promise<void> {
   })
 }
 
-class TestRootIndexer extends RootIndexer {
+export class TestRootIndexer extends RootIndexer {
   public resolveTick: (height: number) => void = () => {}
   public rejectTick: (error: unknown) => void = () => {}
 

--- a/packages/uif/src/BaseIndexer.ts
+++ b/packages/uif/src/BaseIndexer.ts
@@ -55,7 +55,6 @@ export abstract class BaseIndexer implements Indexer {
   /**
    * @param targetHeight - every value > `targetHeight` is invalid, but `targetHeight` itself is valid
    */
-  // TODO: This function can return Promise<number>
   abstract invalidate(targetHeight: number): Promise<number>
 
   private state: IndexerState

--- a/packages/uif/src/SliceIndexer.test.ts
+++ b/packages/uif/src/SliceIndexer.test.ts
@@ -308,7 +308,7 @@ class TestSliceIndexer extends SliceIndexer {
     return this.slices
   }
 
-  getSliceState(): Promise<SliceState[]> {
+  getSliceStates(): Promise<SliceState[]> {
     const sliceHeights = this.repository.getSliceHeights()
     const states = [...sliceHeights.entries()].map(
       ([slice, height]): SliceState => ({

--- a/packages/uif/src/SliceIndexer.test.ts
+++ b/packages/uif/src/SliceIndexer.test.ts
@@ -1,0 +1,344 @@
+import { Logger } from '@l2beat/backend-tools'
+import { expect, mockFn } from 'earl'
+
+import { BaseIndexer } from './BaseIndexer'
+import { TestRootIndexer, waitUntil } from './BaseIndexer.test'
+import { IndexerAction } from './reducer/types/IndexerAction'
+import { RetryStrategy } from './Retries'
+import {
+  diffSlices,
+  SliceHash,
+  SliceIndexer,
+  SliceState,
+  SliceUpdate,
+} from './SliceIndexer'
+
+describe(SliceIndexer.name, () => {
+  it('updates multiple slices', async () => {
+    const repository = testRepositoryFactory()
+
+    const rootIndexer = new TestRootIndexer(0)
+    const sliceIndexer = new TestSliceIndexer(
+      ['token-a', 'token-b', 'token-c'],
+      repository,
+      [rootIndexer],
+    )
+
+    await rootIndexer.start()
+    await sliceIndexer.start()
+
+    await sliceIndexer.finishInvalidate(0)
+    await rootIndexer.doTick(1)
+    await rootIndexer.finishTick(1)
+
+    expect(repository.getSliceData('token-a').get(1)).toEqual(2)
+    expect(repository.getSliceData('token-b').get(1)).toEqual(2)
+    expect(repository.getSliceData('token-c').get(1)).toEqual(2)
+
+    await rootIndexer.doTick(2)
+    await rootIndexer.finishTick(2)
+
+    expect(repository.getSliceData('token-a').get(2)).toEqual(4)
+    expect(repository.getSliceData('token-b').get(2)).toEqual(4)
+    expect(repository.getSliceData('token-c').get(2)).toEqual(4)
+  })
+  it('syncs new token after restart', async () => {
+    const repository = testRepositoryFactory()
+
+    const rootIndexer = new TestRootIndexer(0)
+    const sliceIndexer = new TestSliceIndexer(
+      ['token-a', 'token-b', 'token-c'],
+      repository,
+      [rootIndexer],
+    )
+
+    await rootIndexer.start()
+    await sliceIndexer.start()
+
+    await sliceIndexer.finishInvalidate(0)
+    await rootIndexer.doTick(1)
+    await rootIndexer.finishTick(1)
+
+    expect(repository.getSliceData('token-a').get(1)).toEqual(2)
+    expect(repository.getSliceData('token-b').get(1)).toEqual(2)
+    expect(repository.getSliceData('token-c').get(1)).toEqual(2)
+
+    // creating new instances to simulate restart
+    const newRootIndexer = new TestRootIndexer(1)
+    const newSliceIndexer = new TestSliceIndexer(
+      ['token-a', 'token-b', 'token-c', 'token-d'],
+      repository,
+      [newRootIndexer],
+    )
+
+    await newRootIndexer.start()
+    await newSliceIndexer.start()
+
+    await newSliceIndexer.finishInvalidate(0)
+
+    expect(repository.getSliceData('token-d').get(1)).toEqual(2)
+  })
+  it('drops old token after restart', async () => {
+    const repository = testRepositoryFactory()
+
+    const rootIndexer = new TestRootIndexer(0)
+    const sliceIndexer = new TestSliceIndexer(
+      ['token-a', 'token-b', 'token-c'],
+      repository,
+      [rootIndexer],
+    )
+
+    await rootIndexer.start()
+    await sliceIndexer.start()
+
+    await sliceIndexer.finishInvalidate(0)
+    await rootIndexer.doTick(1)
+    await rootIndexer.finishTick(1)
+
+    expect(repository.getSliceData('token-a').get(1)).toEqual(2)
+    expect(repository.getSliceData('token-b').get(1)).toEqual(2)
+    expect(repository.getSliceData('token-c').get(1)).toEqual(2)
+
+    // creating new instances to simulate restart
+    const newRootIndexer = new TestRootIndexer(1)
+    const newSliceIndexer = new TestSliceIndexer(
+      ['token-a', 'token-b'],
+      repository,
+      [newRootIndexer],
+    )
+
+    await newRootIndexer.start()
+    await newSliceIndexer.start()
+
+    await newSliceIndexer.finishInvalidate(0)
+
+    expect(repository.removeSlices).toHaveBeenCalledWith(['token-c'])
+    expect(repository.getSliceData('token-c').get(1)).toBeNullish()
+  })
+})
+describe(diffSlices.name, () => {
+  describe('height increase', () => {
+    it('marks token-a to update', () => {
+      const expectedSlices: SliceHash[] = ['token-a', 'token-b', 'token-c']
+      const actualSlices: SliceState[] = [
+        { sliceHash: 'token-a', height: 100 },
+        { sliceHash: 'token-b', height: 200 },
+        { sliceHash: 'token-c', height: 300 },
+      ]
+      const from = 100
+      const to = 200
+
+      const { toRemove, toUpdate } = diffSlices(
+        expectedSlices,
+        actualSlices,
+        from,
+        to,
+      )
+
+      expect(toRemove).toEqual([])
+      expect(toUpdate).toEqual([{ sliceHash: 'token-a', from, to }])
+    })
+  })
+  describe('height decrease', () => {
+    it('marks token-a to update', () => {
+      const expectedSlices: SliceHash[] = ['token-a', 'token-b', 'token-c']
+      const actualSlices: SliceState[] = [
+        { sliceHash: 'token-a', height: 100 },
+        { sliceHash: 'token-b', height: 200 },
+        { sliceHash: 'token-c', height: 300 },
+      ]
+      const from = 300
+      const to = 200
+
+      const { toUpdate, toRemove } = diffSlices(
+        expectedSlices,
+        actualSlices,
+        from,
+        to,
+      )
+
+      expect(toRemove).toEqual([])
+      expect(toUpdate).toEqual([{ sliceHash: 'token-a', from, to }])
+    })
+  })
+
+  describe('configuration change', () => {
+    it('marks token-b to removal from slices state', () => {
+      const expectedSlices: SliceHash[] = ['token-a', 'token-c']
+      const actualSlices: SliceState[] = [
+        { sliceHash: 'token-a', height: 100 },
+        { sliceHash: 'token-b', height: 200 },
+        { sliceHash: 'token-c', height: 300 },
+      ]
+      const from = 100
+      const to = 200
+
+      const { toUpdate, toRemove } = diffSlices(
+        expectedSlices,
+        actualSlices,
+        from,
+        to,
+      )
+
+      expect(toRemove).toEqual(['token-b'])
+      expect(toUpdate).toEqual([{ sliceHash: 'token-a', from, to }])
+    })
+
+    it('marks token-d to addition to slices state', () => {
+      const expectedSlices: SliceHash[] = [
+        'token-a',
+        'token-b',
+        'token-c',
+        'token-d',
+      ]
+
+      const actualSlices: SliceState[] = [
+        { sliceHash: 'token-a', height: 200 },
+        { sliceHash: 'token-b', height: 200 },
+        { sliceHash: 'token-c', height: 200 },
+      ]
+
+      const from = 100
+      const to = 200
+
+      const { toUpdate, toRemove } = diffSlices(
+        expectedSlices,
+        actualSlices,
+        from,
+        to,
+      )
+
+      expect(toRemove).toEqual([])
+      expect(toUpdate).toEqual([{ sliceHash: 'token-d', from: 100, to: 200 }])
+    })
+  })
+})
+
+function testRepositoryFactory() {
+  const sliceHeights = new Map<string, number>()
+  const sliceData = new Map<string, Map<number, number>>()
+  let safeHeight = 0
+
+  return {
+    getSliceHeights: mockFn(() => sliceHeights),
+    getSliceData: mockFn(
+      (hash: string) => sliceData.get(hash) ?? new Map<number, number>(),
+    ),
+    removeSlices: mockFn((hashes: string[]) => {
+      for (const hash of hashes) {
+        sliceHeights.delete(hash)
+        sliceData.delete(hash)
+      }
+    }),
+    setSliceHeight: mockFn((hash: string, height: number) => {
+      sliceHeights.set(hash, height)
+    }),
+    setSliceData: mockFn((hash: string, data: Map<number, number>) => {
+      sliceData.set(hash, data)
+    }),
+    getSafeHeight: mockFn(() => {
+      return safeHeight
+    }),
+    setSafeHeight: mockFn((height: number) => {
+      safeHeight = height
+    }),
+  }
+}
+
+class TestSliceIndexer extends SliceIndexer {
+  public resolveInvalidate: (to: number) => void = () => {}
+  public rejectInvalidate: (error: unknown) => void = () => {}
+
+  public dispatchCounter = 0
+
+  async finishInvalidate(result: number | Error): Promise<void> {
+    await waitUntil(() => this.invalidating)
+    const counter = this.dispatchCounter
+    if (typeof result === 'number') {
+      this.resolveInvalidate(result)
+    } else {
+      this.rejectInvalidate(result)
+    }
+    await waitUntil(() => this.dispatchCounter > counter)
+  }
+
+  public invalidating = false
+  public invalidateTo = 0
+
+  constructor(
+    private readonly slices: string[],
+    private readonly repository: ReturnType<typeof testRepositoryFactory>,
+    parents: BaseIndexer[],
+    name?: string,
+    retryStrategy?: {
+      invalidateRetryStrategy?: RetryStrategy
+      updateRetryStrategy?: RetryStrategy
+    },
+  ) {
+    super(Logger.SILENT.tag(name), parents, retryStrategy ?? {})
+
+    const oldDispatch = Reflect.get(this, 'dispatch')
+    Reflect.set(this, 'dispatch', (action: IndexerAction) => {
+      oldDispatch.call(this, action)
+      this.dispatchCounter++
+    })
+  }
+
+  override getMainSafeHeight(): Promise<number> {
+    return Promise.resolve(this.repository.getSafeHeight())
+  }
+
+  override setMainSafeHeight(safeHeight: number): Promise<void> {
+    this.repository.setSafeHeight(safeHeight)
+    return Promise.resolve()
+  }
+
+  override async invalidate(to: number): Promise<number> {
+    this.invalidating = true
+    this.invalidateTo = to
+    return new Promise<number>((resolve, reject) => {
+      this.resolveInvalidate = resolve
+      this.rejectInvalidate = reject
+    }).finally(() => {
+      this.invalidating = false
+    })
+  }
+
+  getExpectedSlices(): string[] {
+    return this.slices
+  }
+
+  getSliceState(): Promise<SliceState[]> {
+    const sliceHeights = this.repository.getSliceHeights()
+    const states = [...sliceHeights.entries()].map(
+      ([slice, height]): SliceState => ({
+        sliceHash: slice,
+        height,
+      }),
+    )
+    return Promise.resolve(states)
+  }
+
+  removeSlices(hashes: string[]): Promise<void> {
+    this.repository.removeSlices(hashes)
+    return Promise.resolve()
+  }
+
+  async updateSlices(updates: SliceUpdate[]): Promise<number> {
+    let minHeight = Infinity
+    for (const update of updates) {
+      const sliceData = this.repository.getSliceData(update.sliceHash)
+
+      for (let i = update.from; i <= update.to; i++) {
+        sliceData.set(i, i * 2)
+      }
+      if (update.to < minHeight) {
+        minHeight = update.to
+      }
+
+      this.repository.setSliceData(update.sliceHash, sliceData)
+      this.repository.setSliceHeight(update.sliceHash, update.to)
+    }
+    return Promise.resolve(minHeight)
+  }
+}

--- a/packages/uif/src/SliceIndexer.ts
+++ b/packages/uif/src/SliceIndexer.ts
@@ -15,10 +15,10 @@ export interface SliceUpdate {
 
 export abstract class SliceIndexer extends ChildIndexer {
   override async update(from: number, to: number): Promise<number> {
-    const slices = await this.getSliceState()
+    const sliceStates = await this.getSliceStates()
     const { toUpdate, toRemove } = diffSlices(
       this.getExpectedSlices(),
-      slices,
+      sliceStates,
       from,
       to,
     )
@@ -40,9 +40,9 @@ export abstract class SliceIndexer extends ChildIndexer {
   }
 
   override async getSafeHeight(): Promise<number> {
-    const slicesState = await this.getSliceState()
+    const sliceStates = await this.getSliceStates()
     const mainSafeHeight = await this.getMainSafeHeight()
-    return Math.min(...slicesState.map((s) => s.height), mainSafeHeight)
+    return Math.min(...sliceStates.map((s) => s.height), mainSafeHeight)
   }
 
   override async setSafeHeight(height: number): Promise<void> {
@@ -67,7 +67,7 @@ export abstract class SliceIndexer extends ChildIndexer {
   /**
    * @returns State for Slices stored in the database
    */
-  abstract getSliceState(): Promise<SliceState[]>
+  abstract getSliceStates(): Promise<SliceState[]>
 
   /**
    * @param hashes Slices that are no longer part of config

--- a/packages/uif/src/SliceIndexer.ts
+++ b/packages/uif/src/SliceIndexer.ts
@@ -23,16 +23,21 @@ export abstract class SliceIndexer extends ChildIndexer {
       to,
     )
 
-    this.logger.info('Update', { toUpdate, toRemove })
+    this.logger.info('Update', {
+      amountToUpdate: toUpdate.length,
+      amountToRemove: toRemove.length,
+    })
 
     if (toRemove.length > 0) {
+      this.logger.debug('Removing slices', { toRemove })
       await this.removeSlices(toRemove)
-      this.logger.debug('Removed slices', { toRemove })
+      this.logger.debug('Removed slices')
     }
 
     if (toUpdate.length > 0) {
+      this.logger.debug('Updating slices', { toUpdate })
       const newHeight = await this.updateSlices(toUpdate)
-      this.logger.debug('Updated slices', { newHeight, toUpdate })
+      this.logger.debug('Updated slices', { newHeight })
       return newHeight
     }
 
@@ -75,6 +80,7 @@ export abstract class SliceIndexer extends ChildIndexer {
   abstract removeSlices(hashes: SliceHash[]): Promise<void>
 
   /**
+   *
    * @param slices Slices that are part of config and need to be updated
    * @returns Minimum of the heights of updated slices
    */

--- a/packages/uif/src/SliceIndexer.ts
+++ b/packages/uif/src/SliceIndexer.ts
@@ -1,0 +1,115 @@
+import { ChildIndexer } from './BaseIndexer'
+
+export type SliceHash = string
+
+export interface SliceState {
+  sliceHash: SliceHash
+  height: number
+}
+
+export interface SliceUpdate {
+  sliceHash: SliceHash
+  from: number
+  to: number
+}
+
+export abstract class SliceIndexer extends ChildIndexer {
+  override async update(from: number, to: number): Promise<number> {
+    const slices = await this.getSliceState()
+    const { toUpdate, toRemove } = diffSlices(
+      this.getExpectedSlices(),
+      slices,
+      from,
+      to,
+    )
+
+    this.logger.info('Update', { toUpdate, toRemove })
+
+    if (toRemove.length > 0) {
+      await this.removeSlices(toRemove)
+      this.logger.debug('Removed slices', { toRemove })
+    }
+
+    if (toUpdate.length > 0) {
+      const newHeight = await this.updateSlices(toUpdate)
+      this.logger.debug('Updated slices', { newHeight, toUpdate })
+      return newHeight
+    }
+
+    return to
+  }
+
+  override async getSafeHeight(): Promise<number> {
+    const slicesState = await this.getSliceState()
+    const mainSafeHeight = await this.getMainSafeHeight()
+    return Math.min(...slicesState.map((s) => s.height), mainSafeHeight)
+  }
+
+  override async setSafeHeight(height: number): Promise<void> {
+    await this.setMainSafeHeight(height)
+  }
+
+  /**
+   * @returns Height of the indexer. Should be saved in persistent storage.
+   */
+  abstract getMainSafeHeight(): Promise<number>
+
+  /**
+   * @param height Height of the indexer. Should be saved in persistent storage.
+   */
+  abstract setMainSafeHeight(height: number): Promise<void>
+
+  /**
+   * @returns Slices derived from config
+   */
+  abstract getExpectedSlices(): SliceHash[]
+
+  /**
+   * @returns State for Slices stored in the database
+   */
+  abstract getSliceState(): Promise<SliceState[]>
+
+  /**
+   * @param hashes Slices that are no longer part of config
+   */
+  abstract removeSlices(hashes: SliceHash[]): Promise<void>
+
+  /**
+   * @param slices Slices that are part of config and need to be updated
+   * @returns Minimum of the heights of updated slices
+   */
+  abstract updateSlices(slices: SliceUpdate[]): Promise<number>
+}
+
+/**
+ * slices toRemove are slices that are no longer part of config
+ */
+export function diffSlices(
+  expectedSlices: SliceHash[],
+  actualSlices: SliceState[],
+  from: number,
+  to: number,
+): { toUpdate: SliceUpdate[]; toRemove: SliceHash[] } {
+  const toUpdate: SliceUpdate[] = []
+  const toRemove: SliceHash[] = []
+
+  for (const slice of actualSlices) {
+    if (!expectedSlices.includes(slice.sliceHash)) {
+      toRemove.push(slice.sliceHash)
+    } else if (slice.height < to) {
+      toUpdate.push({
+        sliceHash: slice.sliceHash,
+        from: Math.max(slice.height, from),
+        to: to,
+      })
+    }
+  }
+
+  for (const slice of expectedSlices) {
+    if (!actualSlices.find((s) => s.sliceHash === slice)) {
+      toUpdate.push({ sliceHash: slice, from: from, to: to })
+    }
+  }
+
+  return { toUpdate, toRemove }
+}

--- a/packages/uif/src/index.ts
+++ b/packages/uif/src/index.ts
@@ -1,3 +1,4 @@
 export * from './BaseIndexer'
 export * from './Indexer'
 export * from './Retries'
+export * from './SliceIndexer'


### PR DESCRIPTION
Resolves L2B-1928

This PR adds an additional class `SliceIndexer`, enabling an Indexer to index several independent states, e.g. Balances of tokens. Those independent states are called `Slices`. We store the height of each of the slices along with `mainHeight`, which is the minimum of parents' heights AND the `safeHeight` of the indexer. The `getSafeHeight` of the `SliceIndexer` returns a minimum of each of the slices' height and the `mainHeight`.

Implementation of the `SliceIndexer` in the user app requires defining the following methods: 
- `abstract getMainSafeHeight(): Promise<number>`
- `abstract setMainSafeHeight(height: number): Promise<void>`
- `abstract getExpectedSlices(): SliceHash[]`
- `abstract getSliceStates(): Promise<SliceState[]>`
- `abstract removeSlices(hashes: SliceHash[]): Promise<void>`
- `abstract updateSlices(slices: SliceUpdate[]): Promise<number>`
- `abstract invalidate(targetHeight: number): Promise<number>` (from BaseIndexer)

Please provide feedback, I'm wondering if `getMainSafeHeight` and `setMainSafeHeight` methods are a good idea. The thinking behind those is so the user does not have to implement `getSafeHeight` as a minimum of slices' state every time, but it can bring some confusion with API differences between `ChildIndexer` and `SliceIndexer`