### PR TITLE
Pick: sync latest backend changes to discovery layer

### DIFF
--- a/.changeset/popular-fans-return.md
+++ b/.changeset/popular-fans-return.md
@@ -1,0 +1,5 @@
+---
+'@l2beat/discovery': minor
+---
+
+Added inline package description, pretty runner output, discovery diff now accepts list of unverified contracts

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@l2beat/discovery",
+  "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
   "version": "0.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/discovery/src/discovery/output/diffDiscovery.test.ts
+++ b/packages/discovery/src/discovery/output/diffDiscovery.test.ts
@@ -104,6 +104,7 @@ describe(diffDiscovery.name, () => {
       {
         name: 'E',
         address: ADDRESS_E,
+        unverified: true,
         upgradeability: {
           type: 'EIP1967 proxy',
           admin: ADMIN,

--- a/packages/discovery/src/discovery/output/diffDiscovery.test.ts
+++ b/packages/discovery/src/discovery/output/diffDiscovery.test.ts
@@ -11,6 +11,7 @@ describe(diffDiscovery.name, () => {
   const ADDRESS_B = EthereumAddress.random()
   const ADDRESS_C = EthereumAddress.random()
   const ADDRESS_D = EthereumAddress.random()
+  const ADDRESS_E = EthereumAddress.random()
 
   const ADMIN = EthereumAddress.random()
   const IMPLEMENTATION = EthereumAddress.random()
@@ -53,6 +54,17 @@ describe(diffDiscovery.name, () => {
         },
         values: {},
       },
+      {
+        name: 'E',
+        address: ADDRESS_E,
+        unverified: true,
+        upgradeability: {
+          type: 'EIP1967 proxy',
+          admin: ADMIN,
+          implementation: IMPLEMENTATION,
+        },
+        values: {},
+      },
     ]
     const discovered: ContractParameters[] = [
       {
@@ -82,6 +94,16 @@ describe(diffDiscovery.name, () => {
       {
         name: 'D',
         address: ADDRESS_D,
+        upgradeability: {
+          type: 'EIP1967 proxy',
+          admin: ADMIN,
+          implementation: IMPLEMENTATION,
+        },
+        values: {},
+      },
+      {
+        name: 'E',
+        address: ADDRESS_E,
         upgradeability: {
           type: 'EIP1967 proxy',
           admin: ADMIN,

--- a/packages/discovery/src/discovery/output/diffDiscovery.ts
+++ b/packages/discovery/src/discovery/output/diffDiscovery.ts
@@ -16,6 +16,7 @@ export function diffDiscovery(
   previous: ContractParameters[],
   current: ContractParameters[],
   config: DiscoveryConfig,
+  unverifiedContracts?: string[],
 ): DiscoveryDiff[] {
   const modifiedOrDeleted: DiscoveryDiff[] = []
 
@@ -29,6 +30,13 @@ export function diffDiscovery(
         address: previousContract.address,
         type: 'deleted',
       })
+      continue
+    }
+
+    if (
+      unverifiedContracts?.includes(currentContract.name) &&
+      !currentContract.unverified
+    ) {
       continue
     }
 

--- a/packages/discovery/src/discovery/runDiscovery.ts
+++ b/packages/discovery/src/discovery/runDiscovery.ts
@@ -83,7 +83,7 @@ export async function dryRunDiscovery(
   )
 
   if (diff.length > 0) {
-    console.log(JSON.stringify(diff))
+    console.log(JSON.stringify(diff, null, 2))
   } else {
     console.log('No changes!')
   }


### PR DESCRIPTION
## What's changed
- Synced backend changes with discovery package due to upcoming migration

## Cherry-pick sources
https://github.com/l2beat/l2beat/pull/1861
https://github.com/l2beat/l2beat/pull/1885

## Sidenotes
Please give me a heads-up in case I missed anything

## Tested?
![image](https://github.com/l2beat/tools/assets/67391475/c5f39a51-ccf1-4484-8048-744e696cc1b3)

![image](https://github.com/l2beat/tools/assets/67391475/894bb759-41ae-4c79-8266-8d1f4b19353a)
