### PR TITLE
Fix assertion error when contract code is not verified

### DIFF
--- a/.changeset/cyan-gifts-smoke.md
+++ b/.changeset/cyan-gifts-smoke.md
@@ -1,0 +1,5 @@
+---
+'@l2beat/discovery': patch
+---
+
+Fix assertion error when contract code is not verified

--- a/.changeset/cyan-gifts-smoke.md
+++ b/.changeset/cyan-gifts-smoke.md
@@ -1,5 +1,0 @@
----
-'@l2beat/discovery': patch
----
-
-Fix assertion error when contract code is not verified

--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.2.1
+
+### Patch Changes
+
+- 9cf579a: Fix assertion error when contract code is not verified
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/discovery/source/SourceCodeService.ts
+++ b/packages/discovery/src/discovery/source/SourceCodeService.ts
@@ -43,7 +43,6 @@ export class SourceCodeService {
     }
 
     const isVerified = metadata.every((x) => x.isVerified)
-    assert(name)
 
     return { name, isVerified, abi, abis, files }
   }

--- a/packages/discovery/src/discovery/source/SourceCodeService.ts
+++ b/packages/discovery/src/discovery/source/SourceCodeService.ts
@@ -1,4 +1,3 @@
-import { assert } from '@l2beat/backend-tools'
 import { zip } from 'lodash'
 
 import { EthereumAddress } from '../../utils/EthereumAddress'

--- a/packages/discovery/src/discovery/source/getDerivedName.ts
+++ b/packages/discovery/src/discovery/source/getDerivedName.ts
@@ -1,5 +1,5 @@
-export function getLegacyDerivedName(names: string[]): string | undefined {
-  return names.length === 2 ? names[1] : names[0]
+export function getLegacyDerivedName(names: string[]): string {
+  return (names.length === 2 ? names[1] : names[0]) ?? ''
 }
 
 export function getDerivedName(names: string[]): string | undefined {


### PR DESCRIPTION
## Context

During a migration to a standalone `discovery` package, a bug was introduced. It resulted in an assertion error being thrown when discovering a contract that is not verified on etherscan. Despite our [Discovery Grafana dashboard](https://l2beat.grafana.net/d/PPJiIqA4k/discovery?orgId=1) knowing about this issue and the amount of errors being thrown during discovery, we did not get any notification about this problem.

Merging this PR will result in `@l2beat/discovery@0.2.1` being published