### PR TITLE
Add manual OpticsBeaconProxy type definitions

### DIFF
--- a/.changeset/metal-sheep-share.md
+++ b/.changeset/metal-sheep-share.md
@@ -1,0 +1,5 @@
+---
+'@l2beat/discovery-types': minor
+---
+
+Add manual OpticsBeaconProxy type def

--- a/packages/discovery-types/src/proxyDetails.ts
+++ b/packages/discovery-types/src/proxyDetails.ts
@@ -16,6 +16,7 @@ export const ManualProxyType = z.enum([
   'zkSpace proxy',
   'Eternal Storage proxy',
   'Polygon Extension proxy',
+  'Optics Beacon proxy',
 ])
 
 export type UpgradeabilityParameters =
@@ -36,6 +37,7 @@ export type UpgradeabilityParameters =
   | EternalStorageProxyUpgradeability
   | PolygonExtensionProxyUpgradeability
   | ZkSpaceProxyUpgradeability
+  | OpticsBeaconProxyUpgradeability
 
 export interface ImmutableUpgradeability {
   type: 'immutable'
@@ -146,4 +148,11 @@ export interface ZkSpaceProxyUpgradeability {
   admin: EthereumAddress
   implementation: EthereumAddress
   additional: EthereumAddress[]
+}
+
+export interface OpticsBeaconProxyUpgradeability {
+  type: 'Optics Beacon proxy'
+  upgradeBeacon: EthereumAddress
+  beaconController: EthereumAddress
+  implementation: EthereumAddress
 }


### PR DESCRIPTION
This PR has to be merged and we need to release this package, so the logic can be implemented in `@l2beat/discovery`