### PR TITLE
Ignore sinceTimestamp in diffing

### DIFF
--- a/.changeset/fresh-shoes-poke.md
+++ b/.changeset/fresh-shoes-poke.md
@@ -1,0 +1,5 @@
+---
+'@l2beat/discovery': patch
+---
+
+Ignore sinceTimestamp in diffing

--- a/packages/discovery/src/discovery/output/diffContracts.ts
+++ b/packages/discovery/src/discovery/output/diffContracts.ts
@@ -7,6 +7,10 @@ export interface FieldDiff {
   after?: string
 }
 
+const PREIGNORED: string[] = [
+    "sinceTimestamp"
+]
+
 export function diffContracts(
   before: ContractParameters,
   after: ContractParameters,
@@ -68,6 +72,10 @@ export function diffContracts(
     if (r.key === undefined) {
       return true
     }
+    if (PREIGNORED.includes(r.key)) {
+        return false
+    }
+
     if (r.key.includes('values.')) {
       for (const i of ignoreInWatchMode) {
         if (r.key.includes(`values.${i}`)) {

--- a/packages/discovery/src/discovery/output/diffContracts.ts
+++ b/packages/discovery/src/discovery/output/diffContracts.ts
@@ -7,9 +7,7 @@ export interface FieldDiff {
   after?: string
 }
 
-const PREIGNORED: string[] = [
-    "sinceTimestamp"
-]
+const PREIGNORED: string[] = ['sinceTimestamp']
 
 export function diffContracts(
   before: ContractParameters,
@@ -73,7 +71,7 @@ export function diffContracts(
       return true
     }
     if (PREIGNORED.includes(r.key)) {
-        return false
+      return false
     }
 
     if (r.key.includes('values.')) {


### PR DESCRIPTION
Ignore sinceTimestamp in diffing a contract, since we a deployment timestamp is not going to change.