### PR TITLE
Fetch logs in batches, with cache-friendly ranges

### DIFF
--- a/.changeset/wild-avocados-push.md
+++ b/.changeset/wild-avocados-push.md
@@ -1,0 +1,5 @@
+---
+'@l2beat/discovery': minor
+---
+
+Support fetching logs in batches

--- a/packages/discovery/src/config/config.discovery.ts
+++ b/packages/discovery/src/config/config.discovery.ts
@@ -20,6 +20,7 @@ export function getDiscoveryCliConfig(cli: CliParameters): DiscoveryCliConfig {
   const discoveryEnabled = cli.mode === 'discover'
   const singleDiscoveryEnabled = cli.mode === 'single-discovery'
   const invertEnabled = cli.mode === 'invert'
+  const chain = getChainConfig(cli.chain)
 
   return {
     invert: invertEnabled && {
@@ -33,12 +34,13 @@ export function getDiscoveryCliConfig(cli: CliParameters): DiscoveryCliConfig {
       dryRun: cli.dryRun,
       dev: cli.dev,
       blockNumber: env.optionalInteger('DISCOVERY_BLOCK_NUMBER'),
+      maxGetLogsRange: chain.rpcGetLogsMaxRange,
     },
     singleDiscovery: singleDiscoveryEnabled && {
       address: cli.address,
       chainId: cli.chain,
     },
-    chain: getChainConfig(cli.chain),
+    chain,
   }
 }
 
@@ -50,6 +52,9 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
       return {
         chainId: ChainId.ETHEREUM,
         rpcUrl: env.string('DISCOVERY_ETHEREUM_RPC_URL'),
+        rpcGetLogsMaxRange: env.optionalInteger(
+          'DISCOVERY_ETHEREUM_RPC_GETLOGS_MAX_RANGE',
+        ),
         etherscanApiKey: env.string('DISCOVERY_ETHEREUM_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.etherscan.io/api',
       }
@@ -57,6 +62,9 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
       return {
         chainId: ChainId.ARBITRUM,
         rpcUrl: env.string('DISCOVERY_ARBITRUM_RPC_URL'),
+        rpcGetLogsMaxRange: env.optionalInteger(
+          'DISCOVERY_ARBITRUM_RPC_GETLOGS_MAX_RANGE',
+        ),
         etherscanApiKey: env.string('DISCOVERY_ARBITRUM_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.arbiscan.io/api',
       }
@@ -64,6 +72,9 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
       return {
         chainId: ChainId.OPTIMISM,
         rpcUrl: env.string('DISCOVERY_OPTIMISM_RPC_URL'),
+        rpcGetLogsMaxRange: env.optionalInteger(
+          'DISCOVERY_OPTIMISM_RPC_GETLOGS_MAX_RANGE',
+        ),
         etherscanApiKey: env.string('DISCOVERY_OPTIMISM_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api-optimistic.etherscan.io/api',
       }
@@ -71,6 +82,9 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
       return {
         chainId: ChainId.POLYGON_POS,
         rpcUrl: env.string('DISCOVERY_POLYGON_POS_RPC_URL'),
+        rpcGetLogsMaxRange: env.optionalInteger(
+          'DISCOVERY_POLYGON_POS_RPC_GETLOGS_MAX_RANGE',
+        ),
         etherscanApiKey: env.string('DISCOVERY_POLYGON_POS_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.polygonscan.com/api',
       }
@@ -78,6 +92,9 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
       return {
         chainId: ChainId.BSC,
         rpcUrl: env.string('DISCOVERY_BSC_RPC_URL'),
+        rpcGetLogsMaxRange: env.optionalInteger(
+          'DISCOVERY_BSC_RPC_GETLOGS_MAX_RANGE',
+        ),
         etherscanApiKey: env.string('DISCOVERY_BSC_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.bscscan.com/api',
       }
@@ -85,6 +102,9 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
       return {
         chainId: ChainId.AVALANCHE,
         rpcUrl: env.string('DISCOVERY_AVALANCHE_RPC_URL'),
+        rpcGetLogsMaxRange: env.optionalInteger(
+          'DISCOVERY_AVALANCHE_RPC_GETLOGS_MAX_RANGE',
+        ),
         etherscanApiKey: env.string('DISCOVERY_AVALANCHE_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.snowtrace.io/api',
       }
@@ -92,6 +112,9 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
       return {
         chainId: ChainId.CELO,
         rpcUrl: env.string('DISCOVERY_CELO_RPC_URL'),
+        rpcGetLogsMaxRange: env.optionalInteger(
+          'DISCOVERY_CELO_RPC_GETLOGS_MAX_RANGE',
+        ),
         etherscanApiKey: env.string('DISCOVERY_CELO_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.celoscan.io/api',
       }
@@ -99,6 +122,9 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
       return {
         chainId: ChainId.LINEA,
         rpcUrl: env.string('DISCOVERY_LINEA_RPC_URL'),
+        rpcGetLogsMaxRange: env.optionalInteger(
+          'DISCOVERY_LINEA_RPC_GETLOGS_MAX_RANGE',
+        ),
         etherscanApiKey: env.string('DISCOVERY_LINEA_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.lineascan.build/api',
       }
@@ -106,6 +132,9 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
       return {
         chainId: ChainId.BASE,
         rpcUrl: env.string('DISCOVERY_BASE_RPC_URL'),
+        rpcGetLogsMaxRange: env.optionalInteger(
+          'DISCOVERY_BASE_RPC_GETLOGS_MAX_RANGE',
+        ),
         etherscanApiKey: env.string('DISCOVERY_BASE_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.basescan.org/api',
       }
@@ -113,6 +142,9 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
       return {
         chainId: ChainId.POLYGON_ZKEVM,
         rpcUrl: env.string('DISCOVERY_POLYGON_ZKEVM_RPC_URL'),
+        rpcGetLogsMaxRange: env.optionalInteger(
+          'DISCOVERY_POLYGON_ZKEVM_RPC_GETLOGS_MAX_RANGE',
+        ),
         etherscanApiKey: env.string(
           'DISCOVERY_POLYGON_ZKEVM_ETHERSCAN_API_KEY',
         ),
@@ -122,6 +154,9 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
       return {
         chainId: ChainId.GNOSIS,
         rpcUrl: env.string('DISCOVERY_GNOSIS_RPC_URL'),
+        rpcGetLogsMaxRange: env.optionalInteger(
+          'DISCOVERY_GNOSIS_RPC_GETLOGS_MAX_RANGE',
+        ),
         etherscanApiKey: env.string('DISCOVERY_GNOSIS_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.gnosisscan.io/api',
       }
@@ -145,6 +180,7 @@ export interface DiscoveryModuleConfig {
   readonly dryRun?: boolean
   readonly dev?: boolean
   readonly blockNumber?: number
+  readonly maxGetLogsRange?: number
 }
 
 export interface SingleDiscoveryModuleConfig {
@@ -155,6 +191,7 @@ export interface SingleDiscoveryModuleConfig {
 export interface DiscoveryChainConfig {
   chainId: ChainId
   rpcUrl: string
+  rpcGetLogsMaxRange?: number
   etherscanApiKey: string
   etherscanUrl: string
 }

--- a/packages/discovery/src/config/config.discovery.ts
+++ b/packages/discovery/src/config/config.discovery.ts
@@ -34,7 +34,7 @@ export function getDiscoveryCliConfig(cli: CliParameters): DiscoveryCliConfig {
       dryRun: cli.dryRun,
       dev: cli.dev,
       blockNumber: env.optionalInteger('DISCOVERY_BLOCK_NUMBER'),
-      maxGetLogsRange: chain.rpcGetLogsMaxRange,
+      getLogsMaxRange: chain.rpcGetLogsMaxRange,
     },
     singleDiscovery: singleDiscoveryEnabled && {
       address: cli.address,
@@ -180,7 +180,7 @@ export interface DiscoveryModuleConfig {
   readonly dryRun?: boolean
   readonly dev?: boolean
   readonly blockNumber?: number
-  readonly maxGetLogsRange?: number
+  readonly getLogsMaxRange?: number
 }
 
 export interface SingleDiscoveryModuleConfig {

--- a/packages/discovery/src/discovery/DiscoveryLogger.ts
+++ b/packages/discovery/src/discovery/DiscoveryLogger.ts
@@ -103,6 +103,11 @@ export class DiscoveryLogger {
       )}`,
     )
   }
+
+  logFetchingEvents(fromBlock: number, toBlock: number): void {
+    const text = `Fetching events in range ${fromBlock} - ${toBlock}`
+    this.log(`  ${chalk.gray(text)}`)
+  }
 }
 
 function dots(length: number): string {

--- a/packages/discovery/src/discovery/analysis/AddressAnalyzer.test.ts
+++ b/packages/discovery/src/discovery/analysis/AddressAnalyzer.test.ts
@@ -60,7 +60,10 @@ describe(AddressAnalyzer.name, () => {
     const addressAnalyzer = new AddressAnalyzer(
       mockObject<DiscoveryProvider>({
         getCode: async () => Bytes.fromHex('0x1234'),
-        getDeploymentTimestamp: async () => new UnixTime(1234),
+        getDeploymentInfo: async () => ({
+          timestamp: new UnixTime(1234),
+          blockNumber: 9876,
+        }),
       }),
       mockObject<ProxyDetector>({
         detectProxy: async () => ({
@@ -100,6 +103,7 @@ describe(AddressAnalyzer.name, () => {
         derivedName: undefined,
         isVerified: true,
         deploymentTimestamp: new UnixTime(1234),
+        deploymentBlockNumber: 9876,
         upgradeability: { type: 'EIP1967 proxy', implementation, admin },
         implementations: [implementation],
         values: { owner: owner.toString() },
@@ -130,7 +134,10 @@ describe(AddressAnalyzer.name, () => {
     const addressAnalyzer = new AddressAnalyzer(
       mockObject<DiscoveryProvider>({
         getCode: async () => Bytes.fromHex('0x1234'),
-        getDeploymentTimestamp: async () => new UnixTime(1234),
+        getDeploymentInfo: async () => ({
+          timestamp: new UnixTime(1234),
+          blockNumber: 9876,
+        }),
       }),
       mockObject<ProxyDetector>({
         detectProxy: async () => ({
@@ -170,6 +177,7 @@ describe(AddressAnalyzer.name, () => {
         address,
         isVerified: false,
         deploymentTimestamp: new UnixTime(1234),
+        deploymentBlockNumber: 9876,
         upgradeability: { type: 'EIP1967 proxy', implementation, admin },
         implementations: [implementation],
         values: { owner: owner.toString() },

--- a/packages/discovery/src/discovery/analysis/AddressAnalyzer.ts
+++ b/packages/discovery/src/discovery/analysis/AddressAnalyzer.ts
@@ -20,6 +20,7 @@ export interface AnalyzedContract {
   address: EthereumAddress
   name: string
   deploymentTimestamp: UnixTime
+  deploymentBlockNumber: number
   derivedName: string | undefined
   isVerified: boolean
   upgradeability: UpgradeabilityParameters
@@ -55,8 +56,10 @@ export class AddressAnalyzer {
       return { analysis: { type: 'EOA', address }, relatives: [] }
     }
 
-    const deploymentTimestamp =
-      await this.provider.getDeploymentTimestamp(address)
+    const {
+      timestamp: deploymentTimestamp,
+      blockNumber: deploymentBlockNumber,
+    } = await this.provider.getDeploymentInfo(address)
 
     const proxy = await this.proxyDetector.detectProxy(
       address,
@@ -86,6 +89,7 @@ export class AddressAnalyzer {
         isVerified: sources.isVerified,
         address,
         deploymentTimestamp,
+        deploymentBlockNumber,
         upgradeability: proxy?.upgradeability ?? { type: 'immutable' },
         implementations: proxy?.implementations ?? [],
         values: values ?? {},

--- a/packages/discovery/src/discovery/output/toDiscoveryOutput.test.ts
+++ b/packages/discovery/src/discovery/output/toDiscoveryOutput.test.ts
@@ -14,6 +14,7 @@ describe(processAnalysis.name, () => {
     values: {},
     isVerified: true,
     deploymentTimestamp: new UnixTime(1234),
+    deploymentBlockNumber: 9876,
     upgradeability: { type: 'immutable' } as UpgradeabilityParameters,
     implementations: [],
     abis: {},

--- a/packages/discovery/src/discovery/provider/DiscoveryProvider.test.ts
+++ b/packages/discovery/src/discovery/provider/DiscoveryProvider.test.ts
@@ -12,6 +12,8 @@ const rangesFromCalls = (provider: MockObject<providers.Provider>) =>
     call.args[0].toBlock,
   ])
 
+const GETLOGS_MAX_RANGE = 10000
+
 describe(DiscoveryProvider.name, () => {
   describe(DiscoveryProvider.prototype.getLogs.name, () => {
     const etherscanLikeClientMock = mockObject<EtherscanLikeClient>({})
@@ -28,6 +30,7 @@ describe(DiscoveryProvider.name, () => {
         providerMock,
         etherscanLikeClientMock,
         DiscoveryLogger.SILENT,
+        GETLOGS_MAX_RANGE,
       )
       discoveryProviderMock.getDeploymentInfo = mockFn().resolvesTo({
         blockNumber: 0,
@@ -101,6 +104,25 @@ describe(DiscoveryProvider.name, () => {
       await discoveryProviderMock.getLogs(address, topics, 1400, 1600)
       const ranges = rangesFromCalls(providerMock)
       expect(ranges).toEqual([[1400, 1600]])
+    })
+
+    it('handles maxGetLogsRange undefined (no range)', async () => {
+      providerMock = mockObject<providers.Provider>({
+        getLogs: mockFn().resolvesTo([]),
+      })
+      discoveryProviderMock = new DiscoveryProvider(
+        providerMock,
+        etherscanLikeClientMock,
+        DiscoveryLogger.SILENT,
+        undefined,
+      )
+      discoveryProviderMock.getDeploymentInfo = mockFn().resolvesTo({
+        blockNumber: 0,
+        timestamp: 0,
+      })
+      await discoveryProviderMock.getLogs(address, topics, 5000, 35000)
+      const ranges = rangesFromCalls(providerMock)
+      expect(ranges).toEqual([[5000, 35000]])
     })
   })
 })

--- a/packages/discovery/src/discovery/provider/DiscoveryProvider.test.ts
+++ b/packages/discovery/src/discovery/provider/DiscoveryProvider.test.ts
@@ -114,7 +114,7 @@ describe(DiscoveryProvider.name, () => {
         providerMock,
         etherscanLikeClientMock,
         DiscoveryLogger.SILENT,
-        undefined,
+        undefined, // PROVIDING UNDEFINED for getLogsMaxRange, so no batching
       )
       discoveryProviderMock.getDeploymentInfo = mockFn().resolvesTo({
         blockNumber: 0,

--- a/packages/discovery/src/discovery/provider/DiscoveryProvider.test.ts
+++ b/packages/discovery/src/discovery/provider/DiscoveryProvider.test.ts
@@ -106,7 +106,7 @@ describe(DiscoveryProvider.name, () => {
       expect(ranges).toEqual([[1400, 1600]])
     })
 
-    it('handles maxGetLogsRange undefined (no range)', async () => {
+    it('handles getLogsMaxRange undefined (no range)', async () => {
       providerMock = mockObject<providers.Provider>({
         getLogs: mockFn().resolvesTo([]),
       })

--- a/packages/discovery/src/discovery/provider/DiscoveryProvider.test.ts
+++ b/packages/discovery/src/discovery/provider/DiscoveryProvider.test.ts
@@ -124,5 +124,29 @@ describe(DiscoveryProvider.name, () => {
       const ranges = rangesFromCalls(providerMock)
       expect(ranges).toEqual([[5000, 35000]])
     })
+
+    it('starts with deployment block if bigger then fromBlock', async () => {
+      providerMock = mockObject<providers.Provider>({
+        getLogs: mockFn().resolvesTo([]),
+      })
+      discoveryProviderMock = new DiscoveryProvider(
+        providerMock,
+        etherscanLikeClientMock,
+        DiscoveryLogger.SILENT,
+        GETLOGS_MAX_RANGE,
+      )
+      discoveryProviderMock.getDeploymentInfo = mockFn().resolvesTo({
+        blockNumber: 16000,
+        timestamp: 0,
+      })
+
+      await discoveryProviderMock.getLogs(address, topics, 5000, 35000)
+      const ranges = rangesFromCalls(providerMock)
+      expect(ranges).toEqual([
+        [16000, 19999],
+        [20000, 29999],
+        [30000, 35000],
+      ])
+    })
   })
 })

--- a/packages/discovery/src/discovery/provider/DiscoveryProvider.test.ts
+++ b/packages/discovery/src/discovery/provider/DiscoveryProvider.test.ts
@@ -1,0 +1,106 @@
+import { expect, mockFn, MockObject, mockObject } from 'earl'
+import { providers } from 'ethers'
+
+import { EthereumAddress } from '../../utils/EthereumAddress'
+import { EtherscanLikeClient } from '../../utils/EtherscanLikeClient'
+import { DiscoveryLogger } from '../DiscoveryLogger'
+import { DiscoveryProvider } from './DiscoveryProvider'
+
+const rangesFromCalls = (provider: MockObject<providers.Provider>) =>
+  provider.getLogs.calls.map((call) => [
+    call.args[0].fromBlock,
+    call.args[0].toBlock,
+  ])
+
+describe(DiscoveryProvider.name, () => {
+  describe(DiscoveryProvider.prototype.getLogs.name, () => {
+    const etherscanLikeClientMock = mockObject<EtherscanLikeClient>({})
+    const address = EthereumAddress.random()
+    const topics = ['testTopic']
+    let providerMock: MockObject<providers.Provider>
+    let discoveryProviderMock: DiscoveryProvider
+
+    beforeEach(() => {
+      providerMock = mockObject<providers.Provider>({
+        getLogs: mockFn().resolvesTo([]),
+      })
+      discoveryProviderMock = new DiscoveryProvider(
+        providerMock,
+        etherscanLikeClientMock,
+        DiscoveryLogger.SILENT,
+      )
+      discoveryProviderMock.getDeploymentInfo = mockFn().resolvesTo({
+        blockNumber: 0,
+        timestamp: 0,
+      })
+    })
+
+    it('handles simple range', async () => {
+      await discoveryProviderMock.getLogs(address, topics, 5000, 35000)
+      const ranges = rangesFromCalls(providerMock)
+      expect(ranges).toEqual([
+        [5000, 9999],
+        [10000, 19999],
+        [20000, 29999],
+        [30000, 35000],
+      ])
+    })
+
+    it('handles range at boundaries', async () => {
+      await discoveryProviderMock.getLogs(address, topics, 10000, 39999)
+      const ranges = rangesFromCalls(providerMock)
+      expect(ranges).toEqual([
+        [10000, 19999],
+        [20000, 29999],
+        [30000, 39999],
+      ])
+    })
+
+    it('handles range at +/- 1 of boundaries', async () => {
+      await discoveryProviderMock.getLogs(address, topics, 9999, 30000)
+      const ranges = rangesFromCalls(providerMock)
+      expect(ranges).toEqual([
+        [9999, 9999],
+        [10000, 19999],
+        [20000, 29999],
+        [30000, 30000],
+      ])
+    })
+
+    it('handles range where from and to are equal and multiply or range', async () => {
+      await discoveryProviderMock.getLogs(address, topics, 10000, 10000)
+      const ranges = rangesFromCalls(providerMock)
+      expect(ranges).toEqual([[10000, 10000]])
+    })
+
+    it('handles range where from and to are -1 of multiply or range', async () => {
+      await discoveryProviderMock.getLogs(address, topics, 9999, 9999)
+      const ranges = rangesFromCalls(providerMock)
+      expect(ranges).toEqual([[9999, 9999]])
+    })
+
+    it('handles range where from and to are +1 of multiply or range', async () => {
+      await discoveryProviderMock.getLogs(address, topics, 10001, 10001)
+      const ranges = rangesFromCalls(providerMock)
+      expect(ranges).toEqual([[10001, 10001]])
+    })
+
+    it('handles range [0,0]', async () => {
+      await discoveryProviderMock.getLogs(address, topics, 0, 0)
+      const ranges = rangesFromCalls(providerMock)
+      expect(ranges).toEqual([[0, 0]])
+    })
+
+    it('handles range [1,1]', async () => {
+      await discoveryProviderMock.getLogs(address, topics, 1, 1)
+      const ranges = rangesFromCalls(providerMock)
+      expect(ranges).toEqual([[1, 1]])
+    })
+
+    it('handles range inside boundaries', async () => {
+      await discoveryProviderMock.getLogs(address, topics, 1400, 1600)
+      const ranges = rangesFromCalls(providerMock)
+      expect(ranges).toEqual([[1400, 1600]])
+    })
+  })
+})

--- a/packages/discovery/src/discovery/provider/DiscoveryProvider.ts
+++ b/packages/discovery/src/discovery/provider/DiscoveryProvider.ts
@@ -31,7 +31,7 @@ export class DiscoveryProvider {
     private readonly provider: providers.Provider,
     private readonly etherscanLikeClient: EtherscanLikeClient,
     private readonly logger: DiscoveryLogger,
-    private readonly maxGetLogsRange?: number,
+    private readonly getLogsMaxRange?: number,
   ) {}
 
   async call(
@@ -71,7 +71,7 @@ export class DiscoveryProvider {
       )
     }
 
-    if (this.maxGetLogsRange === undefined) {
+    if (this.getLogsMaxRange === undefined) {
       return await this.getLogsBatch(address, topics, fromBlock, toBlock)
     }
 
@@ -84,7 +84,7 @@ export class DiscoveryProvider {
     const { blockNumber: deploymentBlockNumber } =
       await this.getDeploymentInfo(address)
 
-    const maxRange = this.maxGetLogsRange
+    const maxRange = this.getLogsMaxRange
     const allLogs: providers.Log[][] = []
 
     let curBoundaryStart

--- a/packages/discovery/src/discovery/provider/DiscoveryProvider.ts
+++ b/packages/discovery/src/discovery/provider/DiscoveryProvider.ts
@@ -87,13 +87,11 @@ export class DiscoveryProvider {
     const maxRange = this.getLogsMaxRange
     const allLogs: providers.Log[][] = []
 
-    let curBoundaryStart
-    let curBoundaryEnd
     let start = Math.max(fromBlock, deploymentBlockNumber)
     let end
     do {
-      curBoundaryStart = Math.floor(start / maxRange) * maxRange
-      curBoundaryEnd = curBoundaryStart + maxRange - 1 // getLogs 'to' is inclusive!
+      const curBoundaryStart = Math.floor(start / maxRange) * maxRange
+      const curBoundaryEnd = curBoundaryStart + maxRange - 1 // getLogs 'to' is inclusive!
       end = Math.min(curBoundaryEnd, toBlock)
       const logs = await this.getLogsBatch(address, topics, start, end)
       allLogs.push(logs)

--- a/packages/discovery/src/discovery/provider/DiscoveryProvider.ts
+++ b/packages/discovery/src/discovery/provider/DiscoveryProvider.ts
@@ -88,11 +88,10 @@ export class DiscoveryProvider {
     const allLogs: providers.Log[][] = []
 
     let start = Math.max(fromBlock, deploymentBlockNumber)
-    let end
     do {
       const curBoundaryStart = Math.floor(start / maxRange) * maxRange
       const curBoundaryEnd = curBoundaryStart + maxRange - 1 // getLogs 'to' is inclusive!
-      end = Math.min(curBoundaryEnd, toBlock)
+      const end = Math.min(curBoundaryEnd, toBlock)
       const logs = await this.getLogsBatch(address, topics, start, end)
       allLogs.push(logs)
       start = end + 1

--- a/packages/discovery/src/discovery/provider/ProviderWithCache.ts
+++ b/packages/discovery/src/discovery/provider/ProviderWithCache.ts
@@ -21,8 +21,9 @@ export class ProviderWithCache extends DiscoveryProvider {
     etherscanClient: EtherscanLikeClient,
     logger: DiscoveryLogger,
     chainId: ChainId,
+    maxGetLogsRange?: number,
   ) {
-    super(provider, etherscanClient, logger)
+    super(provider, etherscanClient, logger, maxGetLogsRange)
     this.cache = new ProviderCache(chainId)
   }
 

--- a/packages/discovery/src/discovery/provider/ProviderWithCache.ts
+++ b/packages/discovery/src/discovery/provider/ProviderWithCache.ts
@@ -21,9 +21,9 @@ export class ProviderWithCache extends DiscoveryProvider {
     etherscanClient: EtherscanLikeClient,
     logger: DiscoveryLogger,
     chainId: ChainId,
-    maxGetLogsRange?: number,
+    getLogsMaxRange?: number,
   ) {
-    super(provider, etherscanClient, logger, maxGetLogsRange)
+    super(provider, etherscanClient, logger, getLogsMaxRange)
     this.cache = new ProviderCache(chainId)
   }
 

--- a/packages/discovery/src/discovery/provider/ProviderWithCache.ts
+++ b/packages/discovery/src/discovery/provider/ProviderWithCache.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { providers } from 'ethers'
 
 import { Bytes } from '../../utils/Bytes'
@@ -5,6 +6,7 @@ import { ChainId } from '../../utils/ChainId'
 import { EthereumAddress } from '../../utils/EthereumAddress'
 import { EtherscanLikeClient } from '../../utils/EtherscanLikeClient'
 import { Hash256 } from '../../utils/Hash256'
+import { DiscoveryLogger } from '../DiscoveryLogger'
 import { isRevert } from '../utils/isRevert'
 import { ContractMetadata, DiscoveryProvider } from './DiscoveryProvider'
 import { ProviderCache } from './ProviderCache'
@@ -17,9 +19,10 @@ export class ProviderWithCache extends DiscoveryProvider {
   constructor(
     provider: providers.Provider,
     etherscanClient: EtherscanLikeClient,
+    logger: DiscoveryLogger,
     chainId: ChainId,
   ) {
-    super(provider, etherscanClient)
+    super(provider, etherscanClient, logger)
     this.cache = new ProviderCache(chainId)
   }
 
@@ -86,16 +89,20 @@ export class ProviderWithCache extends DiscoveryProvider {
     )
   }
 
-  override async getLogs(
+  override async getLogsBatch(
     address: EthereumAddress,
     topics: string[][],
     fromBlock: number,
-    blockNumber: number,
+    toBlock: number,
   ): Promise<providers.Log[]> {
+    const topicsHash: string = createHash('sha256')
+      .update(JSON.stringify(topics))
+      .digest('hex')
+
     return this.cacheOrFetch(
-      `blocks/${blockNumber}`,
-      `getLogs.${address.toString()}.${JSON.stringify(topics)}.${fromBlock}`,
-      () => super.getLogs(address, topics, fromBlock, blockNumber),
+      `logs/${address.toString()}`,
+      `getLogs.${fromBlock}.${toBlock}.${topicsHash}`,
+      () => super.getLogsBatch(address, topics, fromBlock, toBlock),
       identity,
       identity,
     )

--- a/packages/discovery/src/discovery/runDiscovery.ts
+++ b/packages/discovery/src/discovery/runDiscovery.ts
@@ -41,6 +41,7 @@ export async function runDiscovery(
     projectConfig,
     logger,
     blockNumber,
+    config.maxGetLogsRange,
   )
   await saveDiscoveryResult(
     result,
@@ -67,12 +68,19 @@ export async function dryRunDiscovery(
   )
 
   const [discovered, discoveredYesterday] = await Promise.all([
-    justDiscover(provider, etherscanClient, projectConfig, blockNumber),
+    justDiscover(
+      provider,
+      etherscanClient,
+      projectConfig,
+      blockNumber,
+      config.maxGetLogsRange,
+    ),
     justDiscover(
       provider,
       etherscanClient,
       projectConfig,
       blockNumberYesterday,
+      config.maxGetLogsRange,
     ),
   ])
 
@@ -94,6 +102,7 @@ export async function justDiscover(
   etherscanClient: EtherscanLikeClient,
   config: DiscoveryConfig,
   blockNumber: number,
+  maxGetLogsRange?: number,
 ): Promise<DiscoveryOutput> {
   const result = await discover(
     provider,
@@ -101,6 +110,7 @@ export async function justDiscover(
     config,
     DiscoveryLogger.CLI,
     blockNumber,
+    maxGetLogsRange,
   )
 
   const { name } = config
@@ -124,12 +134,14 @@ export async function discover(
   config: DiscoveryConfig,
   logger: DiscoveryLogger,
   blockNumber: number,
+  maxGetLogsRange?: number,
 ): Promise<Analysis[]> {
   const discoveryProvider = new ProviderWithCache(
     provider,
     etherscanClient,
     logger,
     config.chainId,
+    maxGetLogsRange,
   )
   const proxyDetector = new ProxyDetector(discoveryProvider, logger)
   const sourceCodeService = new SourceCodeService(discoveryProvider)

--- a/packages/discovery/src/discovery/runDiscovery.ts
+++ b/packages/discovery/src/discovery/runDiscovery.ts
@@ -41,7 +41,7 @@ export async function runDiscovery(
     projectConfig,
     logger,
     blockNumber,
-    config.maxGetLogsRange,
+    config.getLogsMaxRange,
   )
   await saveDiscoveryResult(
     result,
@@ -73,14 +73,14 @@ export async function dryRunDiscovery(
       etherscanClient,
       projectConfig,
       blockNumber,
-      config.maxGetLogsRange,
+      config.getLogsMaxRange,
     ),
     justDiscover(
       provider,
       etherscanClient,
       projectConfig,
       blockNumberYesterday,
-      config.maxGetLogsRange,
+      config.getLogsMaxRange,
     ),
   ])
 
@@ -102,7 +102,7 @@ export async function justDiscover(
   etherscanClient: EtherscanLikeClient,
   config: DiscoveryConfig,
   blockNumber: number,
-  maxGetLogsRange?: number,
+  getLogsMaxRange?: number,
 ): Promise<DiscoveryOutput> {
   const result = await discover(
     provider,
@@ -110,7 +110,7 @@ export async function justDiscover(
     config,
     DiscoveryLogger.CLI,
     blockNumber,
-    maxGetLogsRange,
+    getLogsMaxRange,
   )
 
   const { name } = config
@@ -134,14 +134,14 @@ export async function discover(
   config: DiscoveryConfig,
   logger: DiscoveryLogger,
   blockNumber: number,
-  maxGetLogsRange?: number,
+  getLogsMaxRange?: number,
 ): Promise<Analysis[]> {
   const discoveryProvider = new ProviderWithCache(
     provider,
     etherscanClient,
     logger,
     config.chainId,
-    maxGetLogsRange,
+    getLogsMaxRange,
   )
   const proxyDetector = new ProxyDetector(discoveryProvider, logger)
   const sourceCodeService = new SourceCodeService(discoveryProvider)

--- a/packages/discovery/src/discovery/runDiscovery.ts
+++ b/packages/discovery/src/discovery/runDiscovery.ts
@@ -128,6 +128,7 @@ export async function discover(
   const discoveryProvider = new ProviderWithCache(
     provider,
     etherscanClient,
+    logger,
     config.chainId,
   )
   const proxyDetector = new ProxyDetector(discoveryProvider, logger)

--- a/packages/discovery/src/singleDiscovery.ts
+++ b/packages/discovery/src/singleDiscovery.ts
@@ -48,6 +48,7 @@ export async function singleDiscovery(
     projectConfig,
     DiscoveryLogger.CLI,
     blockNumber,
+    chainConfig.rpcGetLogsMaxRange,
   )
 
   const discoveryOutput = toDiscoveryOutput(


### PR DESCRIPTION
Resolves L2B-2573

# Rationale

Calling `getLogs()` to Ethereum RPC is slow and resource intensive. That's why most RPC providers limit the range than can be queried in one call (e.g. QuickNode limits to 10,000 block range). 

Up until now we were fine querying Alchemy for range [0-now], because it allows it (it probably uses some custom, efficient index, instead of going through bloom filers of each block, like normal nodes do). But to switch to QuickNode we need to start querying in batches.

# Speed and caching

Since querying in batches is much slower than full range at Alchemy (~1s for full range in Alchemy vs. 5 minutes for the same range in steps from QuickNode or even local node), we need to rely on caching. With cache, after first run, only the most recent range needs to be queried, which is as fast or even faster than what we currently get with Alchemy.

Proposed implementation is cache-friendly. First of all it's caching calls for batches (`getLogsBatch`), not for the top level `getLogs()` call, which is given the full range.  Furthermore, the loop to get batches is not simply starting from `fromBlock` and incrementing by `maxRange`, because that would not hit the cache if for some reason we need to change `fromBlock`. Instead, it keeps constant intervals of maxRange (e.g. 0-10k, 10k-20k, ...) so that intermediate block ranges are always the same, even if the first or last block changes.

# Optimization

The only optimization is querying for the deployment block number, so that we don't need to call `getLogs()` from 0, but from the moment the contract was deployed.

# Future work

Currently cache lives in a file system, so it will be cleared each time on Heroku deployment (and once a day automatically). This is not acceptable given how long the first run takes. To alleviate it, L2B-2601 is worked on to use DB as a cache. This way we can have persistent cache on Heroku, plus keep local cache in sqlite db file.