### PR TITLE
Add DynamicArrayHandler

### DIFF
--- a/.changeset/smart-colts-carry.md
+++ b/.changeset/smart-colts-carry.md
@@ -1,0 +1,5 @@
+---
+'@l2beat/discovery': minor
+---
+
+Add DynamicArrayHandler for fetching the content of internal dynamic arrays.

--- a/packages/discovery/src/discovery/handlers/storageCommon.ts
+++ b/packages/discovery/src/discovery/handlers/storageCommon.ts
@@ -1,0 +1,11 @@
+import * as z from 'zod'
+
+import { Reference } from './reference'
+import { BytesFromString, NumberFromString } from './types'
+
+export const SingleSlot = z.union([
+  z.number().int().nonnegative(),
+  BytesFromString,
+  NumberFromString,
+  Reference,
+])

--- a/packages/discovery/src/discovery/handlers/user/DynamicArrayHandler.test.ts
+++ b/packages/discovery/src/discovery/handlers/user/DynamicArrayHandler.test.ts
@@ -69,14 +69,13 @@ describe(DynamicArrayHandler.name, () => {
     it('does nothing on empty address array', async () => {
       const address = EthereumAddress.random()
       const provider = mockObject<DiscoveryProvider>({
-        getStorage: mockFn()
-          .executesOnce((passedAddress, slot) => {
-            expect(passedAddress).toEqual(address)
-            expect(slot).toEqual(85n)
-            return Bytes.fromHex(
-              '0x0000000000000000000000000000000000000000000000000000000000000000',
-            )
-          })
+        getStorage: mockFn().executesOnce((passedAddress, slot) => {
+          expect(passedAddress).toEqual(address)
+          expect(slot).toEqual(85n)
+          return Bytes.fromHex(
+            '0x0000000000000000000000000000000000000000000000000000000000000000',
+          )
+        }),
       })
 
       const handler = new DynamicArrayHandler(

--- a/packages/discovery/src/discovery/handlers/user/DynamicArrayHandler.test.ts
+++ b/packages/discovery/src/discovery/handlers/user/DynamicArrayHandler.test.ts
@@ -1,0 +1,151 @@
+import { expect, mockFn, mockObject } from 'earl'
+
+import { Bytes } from '../../../utils/Bytes'
+import { EthereumAddress } from '../../../utils/EthereumAddress'
+import { DiscoveryLogger } from '../../DiscoveryLogger'
+import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
+import { DynamicArrayHandler } from './DynamicArrayHandler'
+
+describe(DynamicArrayHandler.name, () => {
+  const BLOCK_NUMBER = 1234
+
+  describe('integration', () => {
+    it('can return non-empty address array', async () => {
+      const address = EthereumAddress.random()
+      const provider = mockObject<DiscoveryProvider>({
+        getStorage: mockFn()
+          .executesOnce((passedAddress, slot) => {
+            expect(passedAddress).toEqual(address)
+            expect(slot).toEqual(85n)
+            return Bytes.fromHex(
+              '0x0000000000000000000000000000000000000000000000000000000000000002',
+            )
+          })
+          .executesOnce((passedAddress, slot) => {
+            expect(passedAddress).toEqual(address)
+            expect(slot).toEqual(
+              BigInt(
+                '0x71beda120aafdd3bb922b360a066d10b7ce81d7ac2ad9874daac46e2282f6b45',
+              ),
+            )
+            return Bytes.fromHex(
+              '0x000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            )
+          })
+          .executesOnce((passedAddress, slot) => {
+            expect(passedAddress).toEqual(address)
+            expect(slot).toEqual(
+              BigInt(
+                '0x71beda120aafdd3bb922b360a066d10b7ce81d7ac2ad9874daac46e2282f6b46',
+              ),
+            )
+            return Bytes.fromHex(
+              '0x000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            )
+          }),
+      })
+
+      const handler = new DynamicArrayHandler(
+        'someName',
+        {
+          type: 'dynamicArray',
+          slot: 85,
+        },
+        DiscoveryLogger.SILENT,
+      )
+      expect(handler.field).toEqual('someName')
+
+      const result = await handler.execute(provider, address, BLOCK_NUMBER, {})
+      expect(result).toEqual({
+        field: 'someName',
+        value: [
+          '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa',
+          '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+        ],
+        ignoreRelative: undefined,
+      })
+    })
+
+    it('does nothing on empty address array', async () => {
+      const address = EthereumAddress.random()
+      const provider = mockObject<DiscoveryProvider>({
+        getStorage: mockFn()
+          .executesOnce((passedAddress, slot) => {
+            expect(passedAddress).toEqual(address)
+            expect(slot).toEqual(85n)
+            return Bytes.fromHex(
+              '0x0000000000000000000000000000000000000000000000000000000000000000',
+            )
+          })
+      })
+
+      const handler = new DynamicArrayHandler(
+        'someName',
+        {
+          type: 'dynamicArray',
+          slot: 85,
+        },
+        DiscoveryLogger.SILENT,
+      )
+      expect(handler.field).toEqual('someName')
+
+      const result = await handler.execute(provider, address, BLOCK_NUMBER, {})
+      expect(result).toEqual({
+        field: 'someName',
+        value: [],
+        ignoreRelative: undefined,
+      })
+    })
+  })
+
+  describe('dependencies', () => {
+    it('detects no dependencies for a simple definition', () => {
+      const handler = new DynamicArrayHandler(
+        'someName',
+        {
+          type: 'dynamicArray',
+          slot: 85,
+        },
+        DiscoveryLogger.SILENT,
+      )
+
+      expect(handler.dependencies).toEqual([])
+    })
+
+    it('detects dependency from the slot field', () => {
+      const handler = new DynamicArrayHandler(
+        'someName',
+        {
+          type: 'dynamicArray',
+          slot: '{{ foo }}',
+        },
+        DiscoveryLogger.SILENT,
+      )
+
+      expect(handler.dependencies).toEqual(['foo'])
+    })
+  })
+
+  it('handles provider errors', async () => {
+    const handler = new DynamicArrayHandler(
+      'someName',
+      {
+        type: 'dynamicArray',
+        slot: 85,
+      },
+      DiscoveryLogger.SILENT,
+    )
+
+    const provider = mockObject<DiscoveryProvider>({
+      async getStorage() {
+        throw new Error('foo bar')
+      },
+    })
+    const address = EthereumAddress.random()
+    const result = await handler.execute(provider, address, BLOCK_NUMBER, {})
+    expect(result).toEqual({
+      field: 'someName',
+      error: 'foo bar',
+    })
+  })
+})

--- a/packages/discovery/src/discovery/handlers/user/DynamicArrayHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/DynamicArrayHandler.ts
@@ -1,0 +1,133 @@
+import { assert } from '@l2beat/backend-tools'
+import { utils } from 'ethers'
+import * as z from 'zod'
+
+import { Bytes } from '../../../utils/Bytes'
+import { EthereumAddress } from '../../../utils/EthereumAddress'
+import { getErrorMessage } from '../../../utils/getErrorMessage'
+import { DiscoveryLogger } from '../../DiscoveryLogger'
+import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
+import { Handler, HandlerResult } from '../Handler'
+import { getReferencedName, Reference, resolveReference } from '../reference'
+import { BytesFromString, NumberFromString } from '../types'
+import { bytes32ToContractValue } from '../utils/bytes32ToContractValue'
+import { valueToBigInt } from '../utils/valueToBigInt'
+
+const SingleSlot = z.union([
+  z.number().int().nonnegative(),
+  BytesFromString,
+  NumberFromString,
+  Reference,
+])
+
+export type DynamicArrayHandlerDefinition = z.infer<
+  typeof DynamicArrayHandlerDefinition
+>
+export const DynamicArrayHandlerDefinition = z.strictObject({
+  type: z.literal('dynamicArray'),
+  slot: SingleSlot,
+  returnType: z.optional(z.enum(['address'])),
+  ignoreRelative: z.optional(z.boolean()),
+})
+
+export class DynamicArrayHandler implements Handler {
+  readonly dependencies: string[]
+
+  constructor(
+    readonly field: string,
+    private readonly definition: DynamicArrayHandlerDefinition,
+    readonly logger: DiscoveryLogger,
+  ) {
+    this.dependencies = getDependencies(definition)
+  }
+
+  async execute(
+    provider: DiscoveryProvider,
+    address: EthereumAddress,
+    blockNumber: number,
+    previousResults: Record<string, HandlerResult | undefined>,
+  ): Promise<HandlerResult> {
+    this.logger.logExecution(this.field, ['Reading dynamic array storage'])
+    const resolved = resolveDependencies(this.definition, previousResults)
+
+    const elementStorages: Bytes[] = []
+    try {
+      const lengthSlot = resolved.slot
+      const lengthStorage = await provider.getStorage(
+        address,
+        lengthSlot,
+        blockNumber,
+      )
+      const length = bytes32ToContractValue(lengthStorage, 'number')
+
+      assert(typeof length === 'number')
+      for (let index = 0n; index < length; index++) {
+        const elementSlot = computeDynamicSlot(lengthSlot, index)
+        const elementStorage = await provider.getStorage(
+          address,
+          elementSlot,
+          blockNumber,
+        )
+        elementStorages.push(elementStorage)
+      }
+    } catch (e) {
+      return { field: this.field, error: getErrorMessage(e) }
+    }
+
+    return {
+      field: this.field,
+      value: elementStorages.map((e) =>
+        bytes32ToContractValue(e, resolved.returnType),
+      ),
+      ignoreRelative: this.definition.ignoreRelative,
+    }
+  }
+}
+
+function getDependencies(definition: DynamicArrayHandlerDefinition): string[] {
+  const dependencies: string[] = []
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  const add = (value: string | undefined) => value && dependencies.push(value)
+
+  add(getReferencedName(definition.slot))
+  if (Array.isArray(definition.slot)) {
+    for (const value of definition.slot) {
+      add(getReferencedName(value))
+    }
+  }
+  return dependencies
+}
+
+function resolveDependencies(
+  definition: DynamicArrayHandlerDefinition,
+  previousResults: Record<string, HandlerResult | undefined>,
+): {
+  slot: bigint
+  returnType: 'number' | 'address' | 'bytes'
+} {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const resolved = resolveReference(definition.slot, previousResults)
+  const slot = valueToBigInt(resolved)
+
+  const returnType = definition.returnType ?? 'address'
+
+  return {
+    slot,
+    returnType,
+  }
+}
+
+function computeDynamicSlot(lengthSlot: bigint, index: bigint): bigint {
+  return hashBigints([lengthSlot]) + index
+}
+
+function hashBigints(values: bigint[]): bigint {
+  return BigInt(
+    utils.keccak256(
+      utils.defaultAbiCoder.encode(
+        values.map(() => 'uint256'),
+        values,
+      ),
+    ),
+  )
+}

--- a/packages/discovery/src/discovery/handlers/user/DynamicArrayHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/DynamicArrayHandler.ts
@@ -13,6 +13,13 @@ import { SingleSlot } from '../storageCommon'
 import { bytes32ToContractValue } from '../utils/bytes32ToContractValue'
 import { valueToBigInt } from '../utils/valueToBigInt'
 
+// Solidity differentiates between two different array types:
+//  - static sized arrays   e.g. address[32]
+//  - dynamic sized arrays  e.g. address[]
+// This handler is designed for dynamically sized arrays and does not work with
+// statically sized arrays! This is because the first slot of a dynamic array
+// contains its length instead of actual data, also the place in storage where
+// the data is located is i = keccak256(slot) instead of i = slot.
 export type DynamicArrayHandlerDefinition = z.infer<
   typeof DynamicArrayHandlerDefinition
 >

--- a/packages/discovery/src/discovery/handlers/user/DynamicArrayHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/DynamicArrayHandler.ts
@@ -8,17 +8,10 @@ import { getErrorMessage } from '../../../utils/getErrorMessage'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
 import { Handler, HandlerResult } from '../Handler'
-import { getReferencedName, Reference, resolveReference } from '../reference'
-import { BytesFromString, NumberFromString } from '../types'
+import { getReferencedName, resolveReference } from '../reference'
+import { SingleSlot } from '../storageCommon'
 import { bytes32ToContractValue } from '../utils/bytes32ToContractValue'
 import { valueToBigInt } from '../utils/valueToBigInt'
-
-const SingleSlot = z.union([
-  z.number().int().nonnegative(),
-  BytesFromString,
-  NumberFromString,
-  Reference,
-])
 
 export type DynamicArrayHandlerDefinition = z.infer<
   typeof DynamicArrayHandlerDefinition

--- a/packages/discovery/src/discovery/handlers/user/StorageHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/StorageHandler.ts
@@ -8,16 +8,10 @@ import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
 import { Handler, HandlerResult } from '../Handler'
 import { getReferencedName, Reference, resolveReference } from '../reference'
-import { BytesFromString, NumberFromString } from '../types'
+import { SingleSlot } from '../storageCommon'
+import { NumberFromString } from '../types'
 import { bytes32ToContractValue } from '../utils/bytes32ToContractValue'
 import { valueToBigInt } from '../utils/valueToBigInt'
-
-const SingleSlot = z.union([
-  z.number().int().nonnegative(),
-  BytesFromString,
-  NumberFromString,
-  Reference,
-])
 
 export type StorageHandlerDefinition = z.infer<typeof StorageHandlerDefinition>
 export const StorageHandlerDefinition = z.strictObject({

--- a/packages/discovery/src/discovery/handlers/user/index.ts
+++ b/packages/discovery/src/discovery/handlers/user/index.ts
@@ -25,6 +25,10 @@ import {
   ConstructorArgsHandler,
 } from './ConstructorArgsHandler'
 import {
+  DynamicArrayHandler,
+  DynamicArrayHandlerDefinition,
+} from './DynamicArrayHandler'
+import {
   EventCountHandler,
   EventCountHandlerDefinition,
 } from './EventCountHandler'
@@ -46,6 +50,8 @@ import { StorageHandler, StorageHandlerDefinition } from './StorageHandler'
 export type UserHandlerDefinition = z.infer<typeof UserHandlerDefinition>
 export const UserHandlerDefinition = z.union([
   StorageHandlerDefinition,
+  DynamicArrayHandlerDefinition,
+  DynamicArrayHandlerDefinition,
   ArrayHandlerDefinition,
   CallHandlerDefinition,
   StarkWareNamedStorageHandlerDefinition,
@@ -69,6 +75,8 @@ export function getUserHandler(
   switch (definition.type) {
     case 'storage':
       return new StorageHandler(field, definition, logger)
+    case 'dynamicArray':
+      return new DynamicArrayHandler(field, definition, logger)
     case 'array':
       return new ArrayHandler(field, definition, abi, logger)
     case 'call':


### PR DESCRIPTION
Resolves L2B-2408

DynamicArrayHandler allows you to fetch internal dynamic arrays from the storage of a contract. It expects that the user provides the starting slot (where the length of the dynamic array is located, it's easy to get this number using a website like [evm.storage](https://evm.storage/)) and the type of the element that is stored. Currently only addresses are supported.