### PR TITLE
Update release action to create .npmrc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,8 @@ jobs:
 
       - run: yarn --frozen-lockfile
       - run: yarn build
+      - run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
       - run: yarn changeset publish


### PR DESCRIPTION
Current version fails with this error:

    🦋  error an error occurred while publishing @l2beat/discovery: ENEEDAUTH This command requires you to be logged in to https://registry.npmjs.org/ 

According to documentation at https://github.com/changesets/action there needs to be a .npmrc created (if we're not explicitly using `changsets/action@v1` which creates this file)