### PR TITLE
Add cache point-in-time identity

### DIFF
--- a/.changeset/happy-brooms-prove.md
+++ b/.changeset/happy-brooms-prove.md
@@ -1,5 +1,0 @@
----
-'@l2beat/discovery': minor
----
-
-Added point-in-time cache reference data

--- a/.changeset/happy-brooms-prove.md
+++ b/.changeset/happy-brooms-prove.md
@@ -1,0 +1,5 @@
+---
+'@l2beat/discovery': minor
+---
+
+Added point-in-time cache reference data

--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.13.0
+
+### Minor Changes
+
+- 0b08f01: Added point-in-time cache reference data
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/discovery/provider/ProviderWithCache.ts
+++ b/packages/discovery/src/discovery/provider/ProviderWithCache.ts
@@ -34,7 +34,7 @@ export interface CacheIdentity {
 
 export interface DiscoveryCache {
   set(identity: CacheIdentity, value: string): Promise<void>
-  get(identity: CacheIdentity): Promise<string | undefined>
+  get(key: string): Promise<string | undefined>
 }
 
 export class ProviderWithCache extends DiscoveryProvider {
@@ -55,7 +55,7 @@ export class ProviderWithCache extends DiscoveryProvider {
     toCache: (value: R) => string,
     fromCache: (value: string) => R,
   ): Promise<R> {
-    const known = await this.cache.get(identity)
+    const known = await this.cache.get(identity.key)
     if (known !== undefined) {
       return fromCache(known)
     }
@@ -258,7 +258,7 @@ export class ProviderWithCache extends DiscoveryProvider {
     // Special cache handling is necessary because
     // we support cases where getContractDeploymentTx API
     // is not available.
-    const cached = await this.cache.get(identity)
+    const cached = await this.cache.get(identity.key)
     if (cached !== undefined) {
       return fromJSON(cached)
     }

--- a/packages/discovery/src/discovery/provider/ProviderWithCache.ts
+++ b/packages/discovery/src/discovery/provider/ProviderWithCache.ts
@@ -14,9 +14,22 @@ import { RateLimitedProvider } from './RateLimitedProvider'
 const toJSON = <T>(x: T): string => JSON.stringify(x)
 const fromJSON = <T>(x: string): T => JSON.parse(x) as T
 
+export interface CacheIdentity {
+  /**
+   * Key constructed from the parameters of the call
+   */
+  key: string
+
+  /**
+   * Block number up to which the cache is valid
+   * If not provided, the cache is valid for all blocks
+   */
+  blockNumber?: number
+}
+
 export interface DiscoveryCache {
-  set(key: string, value: string): Promise<void>
-  get(key: string): Promise<string | undefined>
+  set(identity: CacheIdentity, value: string): Promise<void>
+  get(identity: CacheIdentity): Promise<string | undefined>
 }
 
 export class ProviderWithCache extends DiscoveryProvider {
@@ -32,29 +45,40 @@ export class ProviderWithCache extends DiscoveryProvider {
   }
 
   private async cacheOrFetch<R>(
-    key: string,
+    identity: CacheIdentity,
     fetch: () => Promise<R>,
     toCache: (value: R) => string,
     fromCache: (value: string) => R,
   ): Promise<R> {
-    const known = await this.cache.get(key)
+    const known = await this.cache.get(identity)
     if (known !== undefined) {
       return fromCache(known)
     }
 
     const result = await fetch()
-    await this.cache.set(key, toCache(result))
+    await this.cache.set(identity, toCache(result))
 
     return result
   }
 
-  buildKey(invocation: string, params: { toString: () => string }[]): string {
+  buildIdentity({
+    invocation,
+    blockNumber,
+    params,
+  }: {
+    invocation: string
+    blockNumber?: number
+    params: { toString: () => string }[]
+  }): CacheIdentity {
     const result = [
       this.chainId.toString(),
       invocation,
       ...params.map((p) => p.toString()),
     ]
-    return result.join('.')
+    return {
+      key: result.join('.'),
+      blockNumber,
+    }
   }
 
   override async call(
@@ -62,9 +86,14 @@ export class ProviderWithCache extends DiscoveryProvider {
     data: Bytes,
     blockNumber: number,
   ): Promise<Bytes> {
-    const key = this.buildKey('call', [blockNumber, address, data])
+    const identity = this.buildIdentity({
+      invocation: 'call',
+      blockNumber,
+      params: [blockNumber, address, data],
+    })
+
     const result = await this.cacheOrFetch(
-      key,
+      identity,
       async () => {
         try {
           return {
@@ -93,9 +122,14 @@ export class ProviderWithCache extends DiscoveryProvider {
     slot: number | Bytes,
     blockNumber: number,
   ): Promise<Bytes> {
-    const key = this.buildKey('getStorage', [blockNumber, address, slot])
+    const identity = this.buildIdentity({
+      invocation: 'getStorage',
+      blockNumber,
+      params: [blockNumber, address, slot],
+    })
+
     return this.cacheOrFetch(
-      key,
+      identity,
       () => super.getStorage(address, slot, blockNumber),
       (result) => result.toString(),
       (cached) => Bytes.fromHex(cached),
@@ -112,14 +146,29 @@ export class ProviderWithCache extends DiscoveryProvider {
       .update(JSON.stringify(topics))
       .digest('hex')
 
-    const key = this.buildKey('getLogsBatch', [
-      address,
-      fromBlock,
-      toBlock,
-      topicsHash,
-    ])
+    /**
+     * Passing `toBlock` as a point-in-time reference, so that whenever you are up to the invalidation
+     * you will include whole range of blocks.
+     *
+     * @example
+     *
+     * ```ts
+     * const invalidateAfterBlock = 1000
+     *
+     * const fromBlock = 500
+     * const toBlock = 1500
+     *
+     * await invalidateAfter(invalidateAfterBlock) // catches 1500 and thus whole range
+     * ```
+     */
+    const identity = this.buildIdentity({
+      invocation: 'getLogsBatch',
+      blockNumber: toBlock,
+      params: [address, fromBlock, toBlock, topicsHash],
+    })
+
     return this.cacheOrFetch(
-      key,
+      identity,
       () => super.getLogsBatch(address, topics, fromBlock, toBlock),
       toJSON,
       fromJSON,
@@ -131,9 +180,14 @@ export class ProviderWithCache extends DiscoveryProvider {
     blockNumber: number,
   ): Promise<Bytes> {
     // Ignoring blockNumber here, assuming that code will not change
-    const key = this.buildKey('getCode', [address])
+    const identity = this.buildIdentity({
+      invocation: 'getCode',
+      blockNumber,
+      params: [address],
+    })
+
     return this.cacheOrFetch(
-      key,
+      identity,
       () => super.getCode(address, blockNumber),
       (result) => result.toString(),
       (cached) => Bytes.fromHex(cached),
@@ -143,9 +197,13 @@ export class ProviderWithCache extends DiscoveryProvider {
   override async getTransaction(
     hash: Hash256,
   ): Promise<providers.TransactionResponse> {
-    const key = this.buildKey('getTransaction', [hash])
+    const identity = this.buildIdentity({
+      invocation: 'getTransaction',
+      params: [hash],
+    })
+
     return this.cacheOrFetch(
-      key,
+      identity,
       () => super.getTransaction(hash),
       toJSON,
       fromJSON,
@@ -153,9 +211,14 @@ export class ProviderWithCache extends DiscoveryProvider {
   }
 
   override async getBlock(blockNumber: number): Promise<providers.Block> {
-    const key = this.buildKey('getBlock', [blockNumber])
+    const identity = this.buildIdentity({
+      invocation: 'getBlock',
+      blockNumber,
+      params: [blockNumber],
+    })
+
     return this.cacheOrFetch(
-      key,
+      identity,
       () => super.getBlock(blockNumber),
       toJSON,
       fromJSON,
@@ -165,7 +228,11 @@ export class ProviderWithCache extends DiscoveryProvider {
   override async getMetadata(
     address: EthereumAddress,
   ): Promise<ContractMetadata> {
-    const key = this.buildKey('getMetadata', [address])
+    const key = this.buildIdentity({
+      invocation: 'getMetadata',
+      params: [address],
+    })
+
     return this.cacheOrFetch(
       key,
       () => super.getMetadata(address),
@@ -177,12 +244,15 @@ export class ProviderWithCache extends DiscoveryProvider {
   override async getContractDeploymentTx(
     address: EthereumAddress,
   ): Promise<Hash256 | undefined> {
-    const key = this.buildKey('getContractDeploymentTx', [address])
+    const identity = this.buildIdentity({
+      invocation: 'getContractDeploymentTx',
+      params: [address],
+    })
 
     // Special cache handling is necessary because
     // we support cases where getContractDeploymentTx API
     // is not available.
-    const cached = await this.cache.get(key)
+    const cached = await this.cache.get(identity)
     if (cached !== undefined) {
       return fromJSON(cached)
     }
@@ -190,7 +260,7 @@ export class ProviderWithCache extends DiscoveryProvider {
     const result = await super.getContractDeploymentTx(address)
     // Don't cache "undefined"
     if (result !== undefined) {
-      await this.cache.set(key, toJSON(result))
+      await this.cache.set(identity, toJSON(result))
     }
     return result
   }

--- a/packages/discovery/src/discovery/provider/ProviderWithCache.ts
+++ b/packages/discovery/src/discovery/provider/ProviderWithCache.ts
@@ -38,7 +38,6 @@ export class ProviderWithCache extends DiscoveryProvider {
 
   private async cacheOrFetch<R>(
     key: string,
-    chainId: number,
     blockNumber: number | undefined,
     fetch: () => Promise<R>,
     toCache: (value: R) => string,
@@ -50,7 +49,12 @@ export class ProviderWithCache extends DiscoveryProvider {
     }
 
     const result = await fetch()
-    await this.cache.set(key, toCache(result), chainId, blockNumber)
+    await this.cache.set(
+      key,
+      toCache(result),
+      this.chainId.valueOf(),
+      blockNumber,
+    )
 
     return result
   }
@@ -74,7 +78,6 @@ export class ProviderWithCache extends DiscoveryProvider {
 
     const result = await this.cacheOrFetch(
       key,
-      this.chainId.valueOf(),
       blockNumber,
       async () => {
         try {
@@ -108,7 +111,6 @@ export class ProviderWithCache extends DiscoveryProvider {
 
     return this.cacheOrFetch(
       key,
-      this.chainId.valueOf(),
       blockNumber,
       () => super.getStorage(address, slot, blockNumber),
       (result) => result.toString(),
@@ -150,7 +152,6 @@ export class ProviderWithCache extends DiscoveryProvider {
      */
     return this.cacheOrFetch(
       key,
-      this.chainId.valueOf(),
       toBlock,
       () => super.getLogsBatch(address, topics, fromBlock, toBlock),
       toJSON,
@@ -170,7 +171,6 @@ export class ProviderWithCache extends DiscoveryProvider {
 
     return this.cacheOrFetch(
       key,
-      this.chainId.valueOf(),
       blockNumber,
       () => super.getCode(address, blockNumber),
       (result) => result.toString(),
@@ -185,7 +185,6 @@ export class ProviderWithCache extends DiscoveryProvider {
 
     return this.cacheOrFetch(
       key,
-      this.chainId.valueOf(),
       undefined,
       () => super.getTransaction(hash),
       toJSON,
@@ -198,7 +197,6 @@ export class ProviderWithCache extends DiscoveryProvider {
 
     return this.cacheOrFetch(
       key,
-      this.chainId.valueOf(),
       blockNumber,
       () => super.getBlock(blockNumber),
       toJSON,
@@ -213,7 +211,6 @@ export class ProviderWithCache extends DiscoveryProvider {
 
     return this.cacheOrFetch(
       key,
-      this.chainId.valueOf(),
       undefined,
       () => super.getMetadata(address),
       toJSON,

--- a/packages/discovery/src/discovery/provider/ProviderWithCache.ts
+++ b/packages/discovery/src/discovery/provider/ProviderWithCache.ts
@@ -59,10 +59,10 @@ export class ProviderWithCache extends DiscoveryProvider {
     return result
   }
 
-  buildKey(method: string, params: { toString: () => string }[]): string {
+  buildKey(invocation: string, params: { toString: () => string }[]): string {
     const result = [
       this.chainId.toString(),
-      method,
+      invocation,
       ...params.map((p) => p.toString()),
     ]
 

--- a/packages/discovery/src/discovery/provider/ProviderWithCache.ts
+++ b/packages/discovery/src/discovery/provider/ProviderWithCache.ts
@@ -25,6 +25,11 @@ export interface CacheIdentity {
    * If not provided, the cache is valid for all blocks
    */
   blockNumber?: number
+
+  /**
+   * Chain ID for which the cache is valid
+   */
+  chainId: ChainId
 }
 
 export interface DiscoveryCache {
@@ -78,6 +83,7 @@ export class ProviderWithCache extends DiscoveryProvider {
     return {
       key: result.join('.'),
       blockNumber,
+      chainId: this.chainId,
     }
   }
 
@@ -179,10 +185,10 @@ export class ProviderWithCache extends DiscoveryProvider {
     address: EthereumAddress,
     blockNumber: number,
   ): Promise<Bytes> {
-    // Ignoring blockNumber here, assuming that code will not change
     const identity = this.buildIdentity({
       invocation: 'getCode',
       blockNumber,
+      // Ignoring blockNumber here, assuming that code will not change
       params: [address],
     })
 

--- a/packages/discovery/src/discovery/provider/SQLiteCache.test.ts
+++ b/packages/discovery/src/discovery/provider/SQLiteCache.test.ts
@@ -1,0 +1,137 @@
+import { assert } from '@l2beat/backend-tools'
+import { expect } from 'earl'
+import { existsSync, unlinkSync } from 'fs'
+import sqlite3 from 'sqlite3'
+
+import { SQLiteCache } from './SQLiteCache'
+
+describe('SQLiteCache', () => {
+  it('inserts new cache entry ', () =>
+    withTemporaryFile(async (sqlCache, rqe) => {
+      const key = 'key'
+      const value = 'value'
+      const chainId = 1
+      const blockNumber = 1
+
+      await sqlCache.set(key, value, chainId, blockNumber)
+      const queriedValue = await sqlCache.get(key)
+
+      const resultRaw = await rqe.query<CacheEntry[]>(
+        'SELECT * FROM cache WHERE key=$1',
+        [key],
+      )
+
+      const [result] = resultRaw
+
+      assert(result)
+
+      // Interface
+      expect(queriedValue).toEqual(value)
+
+      // Raw
+      expect(result.key).toEqual(key)
+      expect(result.value).toEqual(value)
+    }))
+
+  it('replaces old value in case of conflict', () =>
+    withTemporaryFile(async (sqlCache, rqe) => {
+      const key = 'key'
+
+      const value = 'value'
+      const chainId = 1
+      const blockNumber = 1
+
+      const newValue = 'newValue'
+      const newChainId = 2
+      const newBlockNumber = 2
+
+      await sqlCache.set(key, value, chainId, blockNumber)
+
+      await sqlCache.set(key, newValue, newChainId, newBlockNumber)
+
+      const resultRaw = await rqe.query<CacheEntry[]>(
+        'SELECT * FROM cache WHERE key=$1',
+        [key],
+      )
+
+      const [result] = resultRaw
+
+      assert(result)
+
+      expect(resultRaw.length).toEqual(1)
+      expect(result.key).toEqual(key)
+      expect(result.value).toEqual(newValue)
+      expect(result.blockNumber).toEqual(newBlockNumber)
+      expect(result.chainId).toEqual(newChainId)
+    }))
+
+  it('transforms undefined into null', () =>
+    withTemporaryFile(async (sqlCache, rqe) => {
+      const key = 'key'
+      const value = 'value'
+      const chainId = 1
+      const blockNumber = undefined
+
+      await sqlCache.set(key, value, chainId, blockNumber)
+
+      const resultRaw = await rqe.query<CacheEntry[]>(
+        'SELECT * FROM cache WHERE key=$1',
+        [key],
+      )
+
+      const [result] = resultRaw
+
+      assert(result)
+
+      expect(result.blockNumber).toEqual(null!)
+    }))
+})
+
+interface CacheEntry {
+  key: string
+  value: string
+  chainId: number
+  blockNumber: number
+}
+
+function randomSqlFile(): string {
+  return `${Math.random().toString(36).substring(7)}.sqlite`
+}
+
+function destroyFile(file: string) {
+  if (existsSync(file)) {
+    unlinkSync(file)
+  }
+}
+
+// Even if test fails miserably, it will still destroy the file despite the outcome
+async function withTemporaryFile<T>(
+  fn: (sqlCache: SQLiteCache, rawQueryExecutor: RawQueryExecutor) => Promise<T>,
+): Promise<T> {
+  const file = randomSqlFile()
+  const sqlCache = new SQLiteCache(file)
+  const rqe = rawQueryExecutor(file)
+  await sqlCache.init()
+
+  return fn(sqlCache, rqe).finally(() => destroyFile(file))
+}
+
+// Just for the sake of out-of-interface testing
+type RawQueryExecutor = ReturnType<typeof rawQueryExecutor>
+
+function rawQueryExecutor(url: string) {
+  const db = new sqlite3.Database(url)
+
+  const query = async <T>(query: string, params: any[] = []): Promise<T> =>
+    new Promise((resolve, reject) => {
+      db.all(query, params, (error, result) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(result as T)
+        }
+      })
+    })
+
+  return { query }
+}

--- a/packages/discovery/src/discovery/provider/SQLiteCache.ts
+++ b/packages/discovery/src/discovery/provider/SQLiteCache.ts
@@ -53,10 +53,10 @@ export class SQLiteCache implements DiscoveryCache {
     try {
       await this.query(
         `
-        INSERT INTO cache(key, blockNumber, value) 
-        VALUES($1, $2, $3) 
-        ON CONFLICT(key) DO UPDATE SET value=$3`,
-        [identity.key, identity.blockNumber, value],
+        INSERT INTO cache(key, blockNumber, chainId, value) 
+        VALUES($1, $2, $3, $4) 
+        ON CONFLICT(key) DO UPDATE SET value=$4`,
+        [identity.key, identity.blockNumber, Number(identity.chainId), value],
       )
     } catch (error) {
       console.error('Error writing to cache', error)

--- a/packages/discovery/src/discovery/provider/SQLiteCache.ts
+++ b/packages/discovery/src/discovery/provider/SQLiteCache.ts
@@ -30,19 +30,11 @@ export class SQLiteCache implements DiscoveryCache {
     `)
   }
 
-  async get(identity: CacheIdentity): Promise<string | undefined> {
-    const andStatement = identity.blockNumber
-      ? 'key=$1 AND chainId=$2 AND blockNumber=$3'
-      : 'key=$1 AND chainId=$2'
-    const andParams = identity.blockNumber
-      ? [identity.key, Number(identity.chainId), identity.blockNumber]
-      : [identity.key, Number(identity.chainId)]
-
+  async get(key: string): Promise<string | undefined> {
     try {
-      const result = (await this.query(
-        `SELECT value FROM cache WHERE ${andStatement}`,
-        andParams,
-      )) as { value: string }[]
+      const result = (await this.query(`SELECT value FROM cache WHERE key=$1`, [
+        key,
+      ])) as { value: string }[]
       return result[0]?.value
     } catch (error) {
       console.error('Error reading from cache', error)

--- a/packages/discovery/src/discovery/provider/SQLiteCache.ts
+++ b/packages/discovery/src/discovery/provider/SQLiteCache.ts
@@ -24,6 +24,7 @@ export class SQLiteCache implements DiscoveryCache {
       CREATE TABLE IF NOT EXISTS cache (
         key TEXT PRIMARY KEY,
         blockNumber INTEGER,
+        chainId INTEGER,
         value TEXT
       )
     `)
@@ -31,15 +32,15 @@ export class SQLiteCache implements DiscoveryCache {
 
   async get(identity: CacheIdentity): Promise<string | undefined> {
     const andStatement = identity.blockNumber
-      ? 'WHERE key=$1 AND blockNumber=$2'
-      : 'WHERE key=$1'
+      ? 'key=$1 AND chainId=$2 AND blockNumber=$3'
+      : 'key=$1 AND chainId=$2'
     const andParams = identity.blockNumber
-      ? [identity.key, identity.blockNumber]
-      : [identity.key]
+      ? [identity.key, Number(identity.chainId), identity.blockNumber]
+      : [identity.key, Number(identity.chainId)]
 
     try {
       const result = (await this.query(
-        `SELECT value FROM cache ${andStatement}`,
+        `SELECT value FROM cache WHERE ${andStatement}`,
         andParams,
       )) as { value: string }[]
       return result[0]?.value

--- a/packages/discovery/src/discovery/provider/SQLiteCache.ts
+++ b/packages/discovery/src/discovery/provider/SQLiteCache.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync } from 'fs'
 import sqlite3 from 'sqlite3' // SQLite Client
 
-import { CacheIdentity, DiscoveryCache } from './ProviderWithCache'
+import { DiscoveryCache } from './ProviderWithCache'
 
 const DEFAULT_DATABASE_DIR = 'cache'
 const DEFAULT_DATABASE_FILENAME = 'discovery.sqlite'
@@ -41,14 +41,19 @@ export class SQLiteCache implements DiscoveryCache {
     }
   }
 
-  async set(identity: CacheIdentity, value: string): Promise<void> {
+  async set(
+    key: string,
+    value: string,
+    chainId: number,
+    blockNumber: number | undefined,
+  ): Promise<void> {
     try {
       await this.query(
         `
         INSERT INTO cache(key, blockNumber, chainId, value) 
         VALUES($1, $2, $3, $4) 
         ON CONFLICT(key) DO UPDATE SET value=$4`,
-        [identity.key, identity.blockNumber, Number(identity.chainId), value],
+        [key, blockNumber, chainId, value],
       )
     } catch (error) {
       console.error('Error writing to cache', error)

--- a/packages/discovery/src/discovery/provider/SQLiteCache.ts
+++ b/packages/discovery/src/discovery/provider/SQLiteCache.ts
@@ -50,10 +50,10 @@ export class SQLiteCache implements DiscoveryCache {
     try {
       await this.query(
         `
-        INSERT INTO cache(key, blockNumber, chainId, value) 
+        INSERT INTO cache(key, value, chainId, blockNumber) 
         VALUES($1, $2, $3, $4) 
-        ON CONFLICT(key) DO UPDATE SET value=$4`,
-        [key, blockNumber, chainId, value],
+        ON CONFLICT(key) DO UPDATE SET value=$2`,
+        [key, value, chainId, blockNumber],
       )
     } catch (error) {
       console.error('Error writing to cache', error)

--- a/packages/discovery/src/discovery/provider/SQLiteCache.ts
+++ b/packages/discovery/src/discovery/provider/SQLiteCache.ts
@@ -32,7 +32,7 @@ export class SQLiteCache implements DiscoveryCache {
 
   async get(key: string): Promise<string | undefined> {
     try {
-      const result = (await this.query(`SELECT value FROM cache WHERE key=$1`, [
+      const result = (await this.query('SELECT value FROM cache WHERE key=$1', [
         key,
       ])) as { value: string }[]
       return result[0]?.value

--- a/packages/discovery/src/discovery/provider/SQLiteCache.ts
+++ b/packages/discovery/src/discovery/provider/SQLiteCache.ts
@@ -52,7 +52,7 @@ export class SQLiteCache implements DiscoveryCache {
         `
         INSERT INTO cache(key, value, chainId, blockNumber) 
         VALUES($1, $2, $3, $4) 
-        ON CONFLICT(key) DO UPDATE SET value=$2, blockNumber=$4`,
+        ON CONFLICT(key) DO UPDATE SET value=$2, chainId=$3, blockNumber=$4`,
         [key, value, chainId, blockNumber],
       )
     } catch (error) {

--- a/packages/discovery/src/discovery/provider/SQLiteCache.ts
+++ b/packages/discovery/src/discovery/provider/SQLiteCache.ts
@@ -52,7 +52,7 @@ export class SQLiteCache implements DiscoveryCache {
         `
         INSERT INTO cache(key, value, chainId, blockNumber) 
         VALUES($1, $2, $3, $4) 
-        ON CONFLICT(key) DO UPDATE SET value=$2`,
+        ON CONFLICT(key) DO UPDATE SET value=$2, blockNumber=$4`,
         [key, value, chainId, blockNumber],
       )
     } catch (error) {


### PR DESCRIPTION
Quick and dirty in-time cache reference discriminated by block number where possible. If cache has no in-time identity, then  null is being inserted.