### PR TITLE
Allow the contract deployment query to fail

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.9.0
+
+### Minor Changes
+
+- Allow the contract deployment query to fail
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/discovery/DiscoveryLogger.ts
+++ b/packages/discovery/src/discovery/DiscoveryLogger.ts
@@ -46,6 +46,10 @@ export class DiscoveryLogger {
     this.log(`  ${chalk.yellow(field)} ${dots(25 - field.length)} ${content}`)
   }
 
+  logWarning(warning: string): void {
+    this.log(`${chalk.yellow(warning)}`)
+  }
+
   logExecutionError(field: string, error: string): void {
     const prefix = 'Error: ' + field
     this.log(`  ${chalk.red(prefix)} ${dots(25 - prefix.length)} ${error}`)

--- a/packages/discovery/src/discovery/analysis/AddressAnalyzer.ts
+++ b/packages/discovery/src/discovery/analysis/AddressAnalyzer.ts
@@ -19,8 +19,8 @@ export interface AnalyzedContract {
   type: 'Contract'
   address: EthereumAddress
   name: string
-  deploymentTimestamp: UnixTime
-  deploymentBlockNumber: number
+  deploymentTimestamp?: UnixTime
+  deploymentBlockNumber?: number
   derivedName: string | undefined
   isVerified: boolean
   upgradeability: UpgradeabilityParameters
@@ -56,10 +56,12 @@ export class AddressAnalyzer {
       return { analysis: { type: 'EOA', address }, relatives: [] }
     }
 
-    const {
-      timestamp: deploymentTimestamp,
-      blockNumber: deploymentBlockNumber,
-    } = await this.provider.getDeploymentInfo(address)
+    let deployment = undefined
+    try {
+      deployment = await this.provider.getDeploymentInfo(address)
+    } catch (_) {
+      _
+    }
 
     const proxy = await this.proxyDetector.detectProxy(
       address,
@@ -88,8 +90,8 @@ export class AddressAnalyzer {
         derivedName: overrides?.name !== undefined ? sources.name : undefined,
         isVerified: sources.isVerified,
         address,
-        deploymentTimestamp,
-        deploymentBlockNumber,
+        deploymentTimestamp: deployment?.timestamp,
+        deploymentBlockNumber: deployment?.blockNumber,
         upgradeability: proxy?.upgradeability ?? { type: 'immutable' },
         implementations: proxy?.implementations ?? [],
         values: values ?? {},

--- a/packages/discovery/src/discovery/analysis/AddressAnalyzer.ts
+++ b/packages/discovery/src/discovery/analysis/AddressAnalyzer.ts
@@ -60,7 +60,16 @@ export class AddressAnalyzer {
     try {
       deployment = await this.provider.getDeploymentInfo(address)
     } catch (e) {
-      this.logger.logWarning(`Failed to fetch contract creation info! [${e}]`)
+      let errorStr = ''
+      if (e instanceof Error) {
+        errorStr = e.toString()
+      } else {
+        errorStr = '<COULD NOT STRINGIFY ERROR>'
+      }
+
+      this.logger.logWarning(
+        `Failed to fetch contract creation info! [${errorStr}]`,
+      )
     }
 
     const proxy = await this.proxyDetector.detectProxy(

--- a/packages/discovery/src/discovery/analysis/AddressAnalyzer.ts
+++ b/packages/discovery/src/discovery/analysis/AddressAnalyzer.ts
@@ -59,8 +59,8 @@ export class AddressAnalyzer {
     let deployment = undefined
     try {
       deployment = await this.provider.getDeploymentInfo(address)
-    } catch (_) {
-      _
+    } catch (e) {
+      this.logger.logWarning(`Failed to fetch contract creation info! [${e}]`)
     }
 
     const proxy = await this.proxyDetector.detectProxy(

--- a/packages/discovery/src/discovery/output/toDiscoveryOutput.ts
+++ b/packages/discovery/src/discovery/output/toDiscoveryOutput.ts
@@ -41,7 +41,7 @@ export function processAnalysis(
           address: x.address,
           unverified: x.isVerified ? undefined : (true as const),
           upgradeability: x.upgradeability,
-          sinceTimestamp: x.deploymentTimestamp.toNumber(),
+          sinceTimestamp: x.deploymentTimestamp?.toNumber(),
           values: Object.keys(x.values).length === 0 ? undefined : x.values,
           errors: Object.keys(x.errors).length === 0 ? undefined : x.errors,
           derivedName: x.derivedName,


### PR DESCRIPTION
Resolves L2B-2722

Celoscan even though it's an Etherscan product does not support the `contract/getcontractcreation` endpoint even though their API docs say it's supported. This PR allows the call to this endpoint to fail and if that happens it will just ignore the `sinceTimestamp` without writing anything into the `discovered.json`.