### PR TITLE
Allow the configured etherscan clients to fail

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.12.0
+
+### Minor Changes
+
+- Etherscan like clients can now configure unsuppoted methods
+
 ## 0.11.0
 
 ### Minor Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/config/config.discovery.ts
+++ b/packages/discovery/src/config/config.discovery.ts
@@ -4,6 +4,7 @@ import { config as dotenv } from 'dotenv'
 import { CliParameters } from '../cli/getCliParameters'
 import { ChainId } from '../utils/ChainId'
 import { EthereumAddress } from '../utils/EthereumAddress'
+import { EtherscanUnsupportedMethods } from '../utils/EtherscanLikeClient'
 
 export function getDiscoveryCliConfig(cli: CliParameters): DiscoveryCliConfig {
   dotenv()
@@ -118,6 +119,9 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
         ),
         etherscanApiKey: env.string('DISCOVERY_CELO_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.celoscan.io/api',
+        etherscanUnsupported: {
+          getContractCreation: true,
+        },
       }
     case ChainId.LINEA:
       return {
@@ -197,6 +201,7 @@ export interface DiscoveryChainConfig {
   rpcGetLogsMaxRange?: number
   etherscanApiKey: string
   etherscanUrl: string
+  etherscanUnsupported?: EtherscanUnsupportedMethods
 }
 
 export interface InversionConfig {

--- a/packages/discovery/src/discovery/analysis/AddressAnalyzer.test.ts
+++ b/packages/discovery/src/discovery/analysis/AddressAnalyzer.test.ts
@@ -1,4 +1,4 @@
-import { expect, mockObject } from 'earl'
+import { expect, mockFn, mockObject } from 'earl'
 
 import { Bytes } from '../../utils/Bytes'
 import { EthereumAddress } from '../../utils/EthereumAddress'
@@ -11,181 +11,256 @@ import { ContractSources, SourceCodeService } from '../source/SourceCodeService'
 import { AddressAnalyzer } from './AddressAnalyzer'
 
 describe(AddressAnalyzer.name, () => {
-  const BLOCK_NUMBER = 1234
+    const BLOCK_NUMBER = 1234
 
-  it('handles EOAs', async () => {
-    const addressAnalyzer = new AddressAnalyzer(
-      mockObject<DiscoveryProvider>({
-        getCode: async () => Bytes.EMPTY,
-      }),
-      mockObject<ProxyDetector>(),
-      mockObject<SourceCodeService>(),
-      mockObject<HandlerExecutor>(),
-      DiscoveryLogger.SILENT,
-    )
+    it('handles EOAs', async () => {
+        const addressAnalyzer = new AddressAnalyzer(
+            mockObject<DiscoveryProvider>({
+                getCode: async () => Bytes.EMPTY,
+            }),
+            mockObject<ProxyDetector>(),
+            mockObject<SourceCodeService>(),
+            mockObject<HandlerExecutor>(),
+            DiscoveryLogger.SILENT,
+        )
 
-    const address = EthereumAddress.random()
-    const result = await addressAnalyzer.analyze(
-      address,
-      undefined,
-      BLOCK_NUMBER,
-    )
+        const address = EthereumAddress.random()
+        const result = await addressAnalyzer.analyze(
+            address,
+            undefined,
+            BLOCK_NUMBER,
+        )
 
-    expect(result).toEqual({
-      analysis: { type: 'EOA', address },
-      relatives: [],
+        expect(result).toEqual({
+            analysis: { type: 'EOA', address },
+            relatives: [],
+        })
     })
-  })
 
-  it('handles contracts', async () => {
-    const address = EthereumAddress.random()
-    const implementation = EthereumAddress.random()
-    const admin = EthereumAddress.random()
-    const owner = EthereumAddress.random()
+    it('handles contracts', async () => {
+        const address = EthereumAddress.random()
+        const implementation = EthereumAddress.random()
+        const admin = EthereumAddress.random()
+        const owner = EthereumAddress.random()
 
-    const sources: ContractSources = {
-      name: 'Test',
-      isVerified: true,
-      abi: ['function foo()', 'function bar()'],
-      abis: {
-        [address.toString()]: ['function foo()'],
-        [implementation.toString()]: ['function bar()'],
-      },
-      files: [
-        { 'Foo.sol': 'contract Test { function foo() {} }' },
-        { 'Bar.sol': 'contract Test { function bar() {} }' },
-      ],
-    }
+        const sources: ContractSources = {
+            name: 'Test',
+            isVerified: true,
+            abi: ['function foo()', 'function bar()'],
+            abis: {
+                [address.toString()]: ['function foo()'],
+                [implementation.toString()]: ['function bar()'],
+            },
+            files: [
+                { 'Foo.sol': 'contract Test { function foo() {} }' },
+                { 'Bar.sol': 'contract Test { function bar() {} }' },
+            ],
+        }
 
-    const addressAnalyzer = new AddressAnalyzer(
-      mockObject<DiscoveryProvider>({
-        getCode: async () => Bytes.fromHex('0x1234'),
-        getDeploymentInfo: async () => ({
-          timestamp: new UnixTime(1234),
-          blockNumber: 9876,
-        }),
-      }),
-      mockObject<ProxyDetector>({
-        detectProxy: async () => ({
-          upgradeability: {
-            type: 'EIP1967 proxy',
-            implementation,
-            admin,
-          },
-          implementations: [implementation],
-          relatives: [admin],
-        }),
-      }),
-      mockObject<SourceCodeService>({
-        getSources: async () => sources,
-      }),
-      mockObject<HandlerExecutor>({
-        execute: async () => ({
-          results: [{ field: 'owner', value: owner.toString() }],
-          values: { owner: owner.toString() },
-          errors: {},
-        }),
-      }),
-      DiscoveryLogger.SILENT,
-    )
+        const addressAnalyzer = new AddressAnalyzer(
+            mockObject<DiscoveryProvider>({
+                getCode: async () => Bytes.fromHex('0x1234'),
+                getDeploymentInfo: async () => ({
+                    timestamp: new UnixTime(1234),
+                    blockNumber: 9876,
+                }),
+            }),
+            mockObject<ProxyDetector>({
+                detectProxy: async () => ({
+                    upgradeability: {
+                        type: 'EIP1967 proxy',
+                        implementation,
+                        admin,
+                    },
+                    implementations: [implementation],
+                    relatives: [admin],
+                }),
+            }),
+            mockObject<SourceCodeService>({
+                getSources: async () => sources,
+            }),
+            mockObject<HandlerExecutor>({
+                execute: async () => ({
+                    results: [{ field: 'owner', value: owner.toString() }],
+                    values: { owner: owner.toString() },
+                    errors: {},
+                }),
+            }),
+            DiscoveryLogger.SILENT,
+        )
 
-    const result = await addressAnalyzer.analyze(
-      address,
-      undefined,
-      BLOCK_NUMBER,
-    )
+        const result = await addressAnalyzer.analyze(
+            address,
+            undefined,
+            BLOCK_NUMBER,
+        )
 
-    expect(result).toEqual({
-      analysis: {
-        type: 'Contract',
-        address,
-        name: 'Test',
-        derivedName: undefined,
-        isVerified: true,
-        deploymentTimestamp: new UnixTime(1234),
-        deploymentBlockNumber: 9876,
-        upgradeability: { type: 'EIP1967 proxy', implementation, admin },
-        implementations: [implementation],
-        values: { owner: owner.toString() },
-        errors: {},
-        abis: sources.abis,
-        sources: sources.files,
-      },
-      relatives: [owner, admin],
+        expect(result).toEqual({
+            analysis: {
+                type: 'Contract',
+                address,
+                name: 'Test',
+                derivedName: undefined,
+                isVerified: true,
+                deploymentTimestamp: new UnixTime(1234),
+                deploymentBlockNumber: 9876,
+                upgradeability: { type: 'EIP1967 proxy', implementation, admin },
+                implementations: [implementation],
+                values: { owner: owner.toString() },
+                errors: {},
+                abis: sources.abis,
+                sources: sources.files,
+            },
+            relatives: [owner, admin],
+        })
     })
-  })
 
-  it('handles unverified contracts', async () => {
-    const address = EthereumAddress.random()
-    const implementation = EthereumAddress.random()
-    const admin = EthereumAddress.random()
-    const owner = EthereumAddress.random()
+    it('handles unverified contracts', async () => {
+        const address = EthereumAddress.random()
+        const implementation = EthereumAddress.random()
+        const admin = EthereumAddress.random()
+        const owner = EthereumAddress.random()
 
-    const sources: ContractSources = {
-      name: 'Test',
-      isVerified: false,
-      abi: ['function foo()'],
-      abis: {
-        [address.toString()]: ['function foo()'],
-      },
-      files: [{ 'Foo.sol': 'contract Test { function foo() {} }' }, {}],
-    }
+        const sources: ContractSources = {
+            name: 'Test',
+            isVerified: false,
+            abi: ['function foo()'],
+            abis: {
+                [address.toString()]: ['function foo()'],
+            },
+            files: [{ 'Foo.sol': 'contract Test { function foo() {} }' }, {}],
+        }
 
-    const addressAnalyzer = new AddressAnalyzer(
-      mockObject<DiscoveryProvider>({
-        getCode: async () => Bytes.fromHex('0x1234'),
-        getDeploymentInfo: async () => ({
-          timestamp: new UnixTime(1234),
-          blockNumber: 9876,
-        }),
-      }),
-      mockObject<ProxyDetector>({
-        detectProxy: async () => ({
-          upgradeability: {
-            type: 'EIP1967 proxy',
-            implementation,
-            admin,
-          },
-          implementations: [implementation],
-          relatives: [admin],
-        }),
-      }),
-      mockObject<SourceCodeService>({
-        getSources: async () => sources,
-      }),
-      mockObject<HandlerExecutor>({
-        execute: async () => ({
-          results: [{ field: 'owner', value: owner.toString() }],
-          values: { owner: owner.toString() },
-          errors: {},
-        }),
-      }),
-      DiscoveryLogger.SILENT,
-    )
+        const addressAnalyzer = new AddressAnalyzer(
+            mockObject<DiscoveryProvider>({
+                getCode: async () => Bytes.fromHex('0x1234'),
+                getDeploymentInfo: async () => ({
+                    timestamp: new UnixTime(1234),
+                    blockNumber: 9876,
+                }),
+            }),
+            mockObject<ProxyDetector>({
+                detectProxy: async () => ({
+                    upgradeability: {
+                        type: 'EIP1967 proxy',
+                        implementation,
+                        admin,
+                    },
+                    implementations: [implementation],
+                    relatives: [admin],
+                }),
+            }),
+            mockObject<SourceCodeService>({
+                getSources: async () => sources,
+            }),
+            mockObject<HandlerExecutor>({
+                execute: async () => ({
+                    results: [{ field: 'owner', value: owner.toString() }],
+                    values: { owner: owner.toString() },
+                    errors: {},
+                }),
+            }),
+            DiscoveryLogger.SILENT,
+        )
 
-    const result = await addressAnalyzer.analyze(
-      address,
-      undefined,
-      BLOCK_NUMBER,
-    )
+        const result = await addressAnalyzer.analyze(
+            address,
+            undefined,
+            BLOCK_NUMBER,
+        )
 
-    expect(result).toEqual({
-      analysis: {
-        type: 'Contract',
-        name: 'Test',
-        derivedName: undefined,
-        address,
-        isVerified: false,
-        deploymentTimestamp: new UnixTime(1234),
-        deploymentBlockNumber: 9876,
-        upgradeability: { type: 'EIP1967 proxy', implementation, admin },
-        implementations: [implementation],
-        values: { owner: owner.toString() },
-        errors: {},
-        abis: sources.abis,
-        sources: sources.files,
-      },
-      relatives: [owner, admin],
+        expect(result).toEqual({
+            analysis: {
+                type: 'Contract',
+                name: 'Test',
+                derivedName: undefined,
+                address,
+                isVerified: false,
+                deploymentTimestamp: new UnixTime(1234),
+                deploymentBlockNumber: 9876,
+                upgradeability: { type: 'EIP1967 proxy', implementation, admin },
+                implementations: [implementation],
+                values: { owner: owner.toString() },
+                errors: {},
+                abis: sources.abis,
+                sources: sources.files,
+            },
+            relatives: [owner, admin],
+        })
     })
-  })
+
+    it('handles contracts while ommiting the sinceTimestamp', async () => {
+        const address = EthereumAddress.random()
+        const implementation = EthereumAddress.random()
+        const admin = EthereumAddress.random()
+        const owner = EthereumAddress.random()
+
+        const sources: ContractSources = {
+            name: 'Test',
+            isVerified: true,
+            abi: ['function foo()', 'function bar()'],
+            abis: {
+                [address.toString()]: ['function foo()'],
+                [implementation.toString()]: ['function bar()'],
+            },
+            files: [
+                { 'Foo.sol': 'contract Test { function foo() {} }' },
+                { 'Bar.sol': 'contract Test { function bar() {} }' },
+            ],
+        }
+
+        const addressAnalyzer = new AddressAnalyzer(
+            mockObject<DiscoveryProvider>({
+                getCode: async () => Bytes.fromHex('0x1234'),
+                getDeploymentInfo: mockFn().throwsOnce(new Error("This method configured set as unsupported"))
+            }),
+            mockObject<ProxyDetector>({
+                detectProxy: async () => ({
+                    upgradeability: {
+                        type: 'EIP1967 proxy',
+                        implementation,
+                        admin,
+                    },
+                    implementations: [implementation],
+                    relatives: [admin],
+                }),
+            }),
+            mockObject<SourceCodeService>({
+                getSources: async () => sources,
+            }),
+            mockObject<HandlerExecutor>({
+                execute: async () => ({
+                    results: [{ field: 'owner', value: owner.toString() }],
+                    values: { owner: owner.toString() },
+                    errors: {},
+                }),
+            }),
+            DiscoveryLogger.SILENT,
+        )
+
+        const result = await addressAnalyzer.analyze(
+            address,
+            undefined,
+            BLOCK_NUMBER,
+        )
+
+        expect(result).toEqual({
+            analysis: {
+                type: 'Contract',
+                address,
+                name: 'Test',
+                derivedName: undefined,
+                deploymentBlockNumber: undefined,
+                deploymentTimestamp: undefined,
+                isVerified: true,
+                upgradeability: { type: 'EIP1967 proxy', implementation, admin },
+                implementations: [implementation],
+                values: { owner: owner.toString() },
+                errors: {},
+                abis: sources.abis,
+                sources: sources.files,
+            },
+            relatives: [owner, admin],
+        })
+    })
 })

--- a/packages/discovery/src/discovery/analysis/AddressAnalyzer.test.ts
+++ b/packages/discovery/src/discovery/analysis/AddressAnalyzer.test.ts
@@ -11,256 +11,256 @@ import { ContractSources, SourceCodeService } from '../source/SourceCodeService'
 import { AddressAnalyzer } from './AddressAnalyzer'
 
 describe(AddressAnalyzer.name, () => {
-    const BLOCK_NUMBER = 1234
+  const BLOCK_NUMBER = 1234
 
-    it('handles EOAs', async () => {
-        const addressAnalyzer = new AddressAnalyzer(
-            mockObject<DiscoveryProvider>({
-                getCode: async () => Bytes.EMPTY,
-            }),
-            mockObject<ProxyDetector>(),
-            mockObject<SourceCodeService>(),
-            mockObject<HandlerExecutor>(),
-            DiscoveryLogger.SILENT,
-        )
+  it('handles EOAs', async () => {
+    const addressAnalyzer = new AddressAnalyzer(
+      mockObject<DiscoveryProvider>({
+        getCode: async () => Bytes.EMPTY,
+      }),
+      mockObject<ProxyDetector>(),
+      mockObject<SourceCodeService>(),
+      mockObject<HandlerExecutor>(),
+      DiscoveryLogger.SILENT,
+    )
 
-        const address = EthereumAddress.random()
-        const result = await addressAnalyzer.analyze(
-            address,
-            undefined,
-            BLOCK_NUMBER,
-        )
+    const address = EthereumAddress.random()
+    const result = await addressAnalyzer.analyze(
+      address,
+      undefined,
+      BLOCK_NUMBER,
+    )
 
-        expect(result).toEqual({
-            analysis: { type: 'EOA', address },
-            relatives: [],
-        })
+    expect(result).toEqual({
+      analysis: { type: 'EOA', address },
+      relatives: [],
     })
+  })
 
-    it('handles contracts', async () => {
-        const address = EthereumAddress.random()
-        const implementation = EthereumAddress.random()
-        const admin = EthereumAddress.random()
-        const owner = EthereumAddress.random()
+  it('handles contracts', async () => {
+    const address = EthereumAddress.random()
+    const implementation = EthereumAddress.random()
+    const admin = EthereumAddress.random()
+    const owner = EthereumAddress.random()
 
-        const sources: ContractSources = {
-            name: 'Test',
-            isVerified: true,
-            abi: ['function foo()', 'function bar()'],
-            abis: {
-                [address.toString()]: ['function foo()'],
-                [implementation.toString()]: ['function bar()'],
-            },
-            files: [
-                { 'Foo.sol': 'contract Test { function foo() {} }' },
-                { 'Bar.sol': 'contract Test { function bar() {} }' },
-            ],
-        }
+    const sources: ContractSources = {
+      name: 'Test',
+      isVerified: true,
+      abi: ['function foo()', 'function bar()'],
+      abis: {
+        [address.toString()]: ['function foo()'],
+        [implementation.toString()]: ['function bar()'],
+      },
+      files: [
+        { 'Foo.sol': 'contract Test { function foo() {} }' },
+        { 'Bar.sol': 'contract Test { function bar() {} }' },
+      ],
+    }
 
-        const addressAnalyzer = new AddressAnalyzer(
-            mockObject<DiscoveryProvider>({
-                getCode: async () => Bytes.fromHex('0x1234'),
-                getDeploymentInfo: async () => ({
-                    timestamp: new UnixTime(1234),
-                    blockNumber: 9876,
-                }),
-            }),
-            mockObject<ProxyDetector>({
-                detectProxy: async () => ({
-                    upgradeability: {
-                        type: 'EIP1967 proxy',
-                        implementation,
-                        admin,
-                    },
-                    implementations: [implementation],
-                    relatives: [admin],
-                }),
-            }),
-            mockObject<SourceCodeService>({
-                getSources: async () => sources,
-            }),
-            mockObject<HandlerExecutor>({
-                execute: async () => ({
-                    results: [{ field: 'owner', value: owner.toString() }],
-                    values: { owner: owner.toString() },
-                    errors: {},
-                }),
-            }),
-            DiscoveryLogger.SILENT,
-        )
+    const addressAnalyzer = new AddressAnalyzer(
+      mockObject<DiscoveryProvider>({
+        getCode: async () => Bytes.fromHex('0x1234'),
+        getDeploymentInfo: async () => ({
+          timestamp: new UnixTime(1234),
+          blockNumber: 9876,
+        }),
+      }),
+      mockObject<ProxyDetector>({
+        detectProxy: async () => ({
+          upgradeability: {
+            type: 'EIP1967 proxy',
+            implementation,
+            admin,
+          },
+          implementations: [implementation],
+          relatives: [admin],
+        }),
+      }),
+      mockObject<SourceCodeService>({
+        getSources: async () => sources,
+      }),
+      mockObject<HandlerExecutor>({
+        execute: async () => ({
+          results: [{ field: 'owner', value: owner.toString() }],
+          values: { owner: owner.toString() },
+          errors: {},
+        }),
+      }),
+      DiscoveryLogger.SILENT,
+    )
 
-        const result = await addressAnalyzer.analyze(
-            address,
-            undefined,
-            BLOCK_NUMBER,
-        )
+    const result = await addressAnalyzer.analyze(
+      address,
+      undefined,
+      BLOCK_NUMBER,
+    )
 
-        expect(result).toEqual({
-            analysis: {
-                type: 'Contract',
-                address,
-                name: 'Test',
-                derivedName: undefined,
-                isVerified: true,
-                deploymentTimestamp: new UnixTime(1234),
-                deploymentBlockNumber: 9876,
-                upgradeability: { type: 'EIP1967 proxy', implementation, admin },
-                implementations: [implementation],
-                values: { owner: owner.toString() },
-                errors: {},
-                abis: sources.abis,
-                sources: sources.files,
-            },
-            relatives: [owner, admin],
-        })
+    expect(result).toEqual({
+      analysis: {
+        type: 'Contract',
+        address,
+        name: 'Test',
+        derivedName: undefined,
+        isVerified: true,
+        deploymentTimestamp: new UnixTime(1234),
+        deploymentBlockNumber: 9876,
+        upgradeability: { type: 'EIP1967 proxy', implementation, admin },
+        implementations: [implementation],
+        values: { owner: owner.toString() },
+        errors: {},
+        abis: sources.abis,
+        sources: sources.files,
+      },
+      relatives: [owner, admin],
     })
+  })
 
-    it('handles unverified contracts', async () => {
-        const address = EthereumAddress.random()
-        const implementation = EthereumAddress.random()
-        const admin = EthereumAddress.random()
-        const owner = EthereumAddress.random()
+  it('handles unverified contracts', async () => {
+    const address = EthereumAddress.random()
+    const implementation = EthereumAddress.random()
+    const admin = EthereumAddress.random()
+    const owner = EthereumAddress.random()
 
-        const sources: ContractSources = {
-            name: 'Test',
-            isVerified: false,
-            abi: ['function foo()'],
-            abis: {
-                [address.toString()]: ['function foo()'],
-            },
-            files: [{ 'Foo.sol': 'contract Test { function foo() {} }' }, {}],
-        }
+    const sources: ContractSources = {
+      name: 'Test',
+      isVerified: false,
+      abi: ['function foo()'],
+      abis: {
+        [address.toString()]: ['function foo()'],
+      },
+      files: [{ 'Foo.sol': 'contract Test { function foo() {} }' }, {}],
+    }
 
-        const addressAnalyzer = new AddressAnalyzer(
-            mockObject<DiscoveryProvider>({
-                getCode: async () => Bytes.fromHex('0x1234'),
-                getDeploymentInfo: async () => ({
-                    timestamp: new UnixTime(1234),
-                    blockNumber: 9876,
-                }),
-            }),
-            mockObject<ProxyDetector>({
-                detectProxy: async () => ({
-                    upgradeability: {
-                        type: 'EIP1967 proxy',
-                        implementation,
-                        admin,
-                    },
-                    implementations: [implementation],
-                    relatives: [admin],
-                }),
-            }),
-            mockObject<SourceCodeService>({
-                getSources: async () => sources,
-            }),
-            mockObject<HandlerExecutor>({
-                execute: async () => ({
-                    results: [{ field: 'owner', value: owner.toString() }],
-                    values: { owner: owner.toString() },
-                    errors: {},
-                }),
-            }),
-            DiscoveryLogger.SILENT,
-        )
+    const addressAnalyzer = new AddressAnalyzer(
+      mockObject<DiscoveryProvider>({
+        getCode: async () => Bytes.fromHex('0x1234'),
+        getDeploymentInfo: async () => ({
+          timestamp: new UnixTime(1234),
+          blockNumber: 9876,
+        }),
+      }),
+      mockObject<ProxyDetector>({
+        detectProxy: async () => ({
+          upgradeability: {
+            type: 'EIP1967 proxy',
+            implementation,
+            admin,
+          },
+          implementations: [implementation],
+          relatives: [admin],
+        }),
+      }),
+      mockObject<SourceCodeService>({
+        getSources: async () => sources,
+      }),
+      mockObject<HandlerExecutor>({
+        execute: async () => ({
+          results: [{ field: 'owner', value: owner.toString() }],
+          values: { owner: owner.toString() },
+          errors: {},
+        }),
+      }),
+      DiscoveryLogger.SILENT,
+    )
 
-        const result = await addressAnalyzer.analyze(
-            address,
-            undefined,
-            BLOCK_NUMBER,
-        )
+    const result = await addressAnalyzer.analyze(
+      address,
+      undefined,
+      BLOCK_NUMBER,
+    )
 
-        expect(result).toEqual({
-            analysis: {
-                type: 'Contract',
-                name: 'Test',
-                derivedName: undefined,
-                address,
-                isVerified: false,
-                deploymentTimestamp: new UnixTime(1234),
-                deploymentBlockNumber: 9876,
-                upgradeability: { type: 'EIP1967 proxy', implementation, admin },
-                implementations: [implementation],
-                values: { owner: owner.toString() },
-                errors: {},
-                abis: sources.abis,
-                sources: sources.files,
-            },
-            relatives: [owner, admin],
-        })
+    expect(result).toEqual({
+      analysis: {
+        type: 'Contract',
+        name: 'Test',
+        derivedName: undefined,
+        address,
+        isVerified: false,
+        deploymentTimestamp: new UnixTime(1234),
+        deploymentBlockNumber: 9876,
+        upgradeability: { type: 'EIP1967 proxy', implementation, admin },
+        implementations: [implementation],
+        values: { owner: owner.toString() },
+        errors: {},
+        abis: sources.abis,
+        sources: sources.files,
+      },
+      relatives: [owner, admin],
     })
+  })
 
-    it('handles contracts while omitting the sinceTimestamp', async () => {
-        const address = EthereumAddress.random()
-        const implementation = EthereumAddress.random()
-        const admin = EthereumAddress.random()
-        const owner = EthereumAddress.random()
+  it('handles contracts while omitting the sinceTimestamp', async () => {
+    const address = EthereumAddress.random()
+    const implementation = EthereumAddress.random()
+    const admin = EthereumAddress.random()
+    const owner = EthereumAddress.random()
 
-        const sources: ContractSources = {
-            name: 'Test',
-            isVerified: true,
-            abi: ['function foo()', 'function bar()'],
-            abis: {
-                [address.toString()]: ['function foo()'],
-                [implementation.toString()]: ['function bar()'],
-            },
-            files: [
-                { 'Foo.sol': 'contract Test { function foo() {} }' },
-                { 'Bar.sol': 'contract Test { function bar() {} }' },
-            ],
-        }
+    const sources: ContractSources = {
+      name: 'Test',
+      isVerified: true,
+      abi: ['function foo()', 'function bar()'],
+      abis: {
+        [address.toString()]: ['function foo()'],
+        [implementation.toString()]: ['function bar()'],
+      },
+      files: [
+        { 'Foo.sol': 'contract Test { function foo() {} }' },
+        { 'Bar.sol': 'contract Test { function bar() {} }' },
+      ],
+    }
 
-        const addressAnalyzer = new AddressAnalyzer(
-            mockObject<DiscoveryProvider>({
-                getCode: async () => Bytes.fromHex('0x1234'),
-                getDeploymentInfo: mockFn().resolvesTo(undefined),
-            }),
-            mockObject<ProxyDetector>({
-                detectProxy: async () => ({
-                    upgradeability: {
-                        type: 'EIP1967 proxy',
-                        implementation,
-                        admin,
-                    },
-                    implementations: [implementation],
-                    relatives: [admin],
-                }),
-            }),
-            mockObject<SourceCodeService>({
-                getSources: async () => sources,
-            }),
-            mockObject<HandlerExecutor>({
-                execute: async () => ({
-                    results: [{ field: 'owner', value: owner.toString() }],
-                    values: { owner: owner.toString() },
-                    errors: {},
-                }),
-            }),
-            DiscoveryLogger.SILENT,
-        )
+    const addressAnalyzer = new AddressAnalyzer(
+      mockObject<DiscoveryProvider>({
+        getCode: async () => Bytes.fromHex('0x1234'),
+        getDeploymentInfo: mockFn().resolvesTo(undefined),
+      }),
+      mockObject<ProxyDetector>({
+        detectProxy: async () => ({
+          upgradeability: {
+            type: 'EIP1967 proxy',
+            implementation,
+            admin,
+          },
+          implementations: [implementation],
+          relatives: [admin],
+        }),
+      }),
+      mockObject<SourceCodeService>({
+        getSources: async () => sources,
+      }),
+      mockObject<HandlerExecutor>({
+        execute: async () => ({
+          results: [{ field: 'owner', value: owner.toString() }],
+          values: { owner: owner.toString() },
+          errors: {},
+        }),
+      }),
+      DiscoveryLogger.SILENT,
+    )
 
-        const result = await addressAnalyzer.analyze(
-            address,
-            undefined,
-            BLOCK_NUMBER,
-        )
+    const result = await addressAnalyzer.analyze(
+      address,
+      undefined,
+      BLOCK_NUMBER,
+    )
 
-        expect(result).toEqual({
-            analysis: {
-                type: 'Contract',
-                address,
-                name: 'Test',
-                derivedName: undefined,
-                deploymentBlockNumber: undefined,
-                deploymentTimestamp: undefined,
-                isVerified: true,
-                upgradeability: { type: 'EIP1967 proxy', implementation, admin },
-                implementations: [implementation],
-                values: { owner: owner.toString() },
-                errors: {},
-                abis: sources.abis,
-                sources: sources.files,
-            },
-            relatives: [owner, admin],
-        })
+    expect(result).toEqual({
+      analysis: {
+        type: 'Contract',
+        address,
+        name: 'Test',
+        derivedName: undefined,
+        deploymentBlockNumber: undefined,
+        deploymentTimestamp: undefined,
+        isVerified: true,
+        upgradeability: { type: 'EIP1967 proxy', implementation, admin },
+        implementations: [implementation],
+        values: { owner: owner.toString() },
+        errors: {},
+        abis: sources.abis,
+        sources: sources.files,
+      },
+      relatives: [owner, admin],
     })
+  })
 })

--- a/packages/discovery/src/discovery/analysis/AddressAnalyzer.test.ts
+++ b/packages/discovery/src/discovery/analysis/AddressAnalyzer.test.ts
@@ -189,7 +189,7 @@ describe(AddressAnalyzer.name, () => {
         })
     })
 
-    it('handles contracts while ommiting the sinceTimestamp', async () => {
+    it('handles contracts while omitting the sinceTimestamp', async () => {
         const address = EthereumAddress.random()
         const implementation = EthereumAddress.random()
         const admin = EthereumAddress.random()
@@ -212,7 +212,7 @@ describe(AddressAnalyzer.name, () => {
         const addressAnalyzer = new AddressAnalyzer(
             mockObject<DiscoveryProvider>({
                 getCode: async () => Bytes.fromHex('0x1234'),
-                getDeploymentInfo: mockFn().throwsOnce(new Error("This method configured set as unsupported"))
+                getDeploymentInfo: mockFn().resolvesTo(undefined),
             }),
             mockObject<ProxyDetector>({
                 detectProxy: async () => ({

--- a/packages/discovery/src/discovery/analysis/AddressAnalyzer.ts
+++ b/packages/discovery/src/discovery/analysis/AddressAnalyzer.ts
@@ -12,7 +12,6 @@ import { DiscoveryProvider } from '../provider/DiscoveryProvider'
 import { ProxyDetector } from '../proxies/ProxyDetector'
 import { SourceCodeService } from '../source/SourceCodeService'
 import { getRelatives } from './getRelatives'
-import { EtherscanLikeClient } from '../../utils/EtherscanLikeClient'
 
 export type Analysis = AnalyzedContract | AnalyzedEOA
 
@@ -57,18 +56,7 @@ export class AddressAnalyzer {
       return { analysis: { type: 'EOA', address }, relatives: [] }
     }
 
-    let deployment = undefined
-    try {
-      deployment = await this.provider.getDeploymentInfo(address)
-    } catch (e) {
-      if (EtherscanLikeClient.errorMeansUnsupported(e)) {
-        this.logger.logWarning(
-          `Getting deployment info is unsupported by Etherscan like endpoint`,
-        )
-      } else {
-        throw e
-      }
-    }
+    const deployment = await this.provider.getDeploymentInfo(address)
 
     const proxy = await this.proxyDetector.detectProxy(
       address,

--- a/packages/discovery/src/discovery/analysis/AddressAnalyzer.ts
+++ b/packages/discovery/src/discovery/analysis/AddressAnalyzer.ts
@@ -12,6 +12,7 @@ import { DiscoveryProvider } from '../provider/DiscoveryProvider'
 import { ProxyDetector } from '../proxies/ProxyDetector'
 import { SourceCodeService } from '../source/SourceCodeService'
 import { getRelatives } from './getRelatives'
+import { EtherscanLikeClient } from '../../utils/EtherscanLikeClient'
 
 export type Analysis = AnalyzedContract | AnalyzedEOA
 
@@ -60,16 +61,13 @@ export class AddressAnalyzer {
     try {
       deployment = await this.provider.getDeploymentInfo(address)
     } catch (e) {
-      let errorStr = ''
-      if (e instanceof Error) {
-        errorStr = e.toString()
+      if (EtherscanLikeClient.errorMeansUnsupported(e)) {
+        this.logger.logWarning(
+          `Getting deployment info is unsupported by Etherscan like endpoint`,
+        )
       } else {
-        errorStr = '<COULD NOT STRINGIFY ERROR>'
+        throw e
       }
-
-      this.logger.logWarning(
-        `Failed to fetch contract creation info! [${errorStr}]`,
-      )
     }
 
     const proxy = await this.proxyDetector.detectProxy(

--- a/packages/discovery/src/discovery/handlers/user/ConstructorArgsHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/ConstructorArgsHandler.ts
@@ -69,6 +69,12 @@ export class ConstructorArgsHandler implements Handler {
     address: EthereumAddress,
   ): Promise<ethers.utils.Result> {
     const deploymentTxHash = await provider.getContractDeploymentTx(address)
+    if (deploymentTxHash === undefined) {
+      throw new Error(
+        "Can't discover constructor because getContractDeploymentTx is not available",
+      )
+    }
+
     const deploymentTx = await provider.getTransaction(deploymentTxHash)
 
     const decodedConstructorArguments = decodeConstructorArgs(

--- a/packages/discovery/src/discovery/proxies/auto/StarkWareProxyGovernance.ts
+++ b/packages/discovery/src/discovery/proxies/auto/StarkWareProxyGovernance.ts
@@ -11,6 +11,10 @@ export async function getProxyGovernance(
   blockNumber: number,
 ): Promise<EthereumAddress[]> {
   const deployer = await provider.getDeployer(address)
+  if (!deployer) {
+    throw new Error('Unable to fetch deployer for StarkWare Proxy governance')
+  }
+
   const fullGovernance = await getFullGovernance(
     provider,
     address,

--- a/packages/discovery/src/utils/EtherscanClient.ts
+++ b/packages/discovery/src/utils/EtherscanClient.ts
@@ -1,7 +1,10 @@
 import { Logger } from '@l2beat/backend-tools'
 
 import { ChainId } from './ChainId'
-import { EtherscanLikeClient } from './EtherscanLikeClient'
+import {
+  EtherscanLikeClient,
+  EtherscanUnsupportedMethods,
+} from './EtherscanLikeClient'
 import { HttpClient } from './HttpClient'
 import { UnixTime } from './UnixTime'
 
@@ -14,9 +17,17 @@ export class EtherscanClient extends EtherscanLikeClient {
     httpClient: HttpClient,
     apiKey: string,
     minTimestamp: UnixTime,
+    unsupportedMethods: EtherscanUnsupportedMethods = {},
     logger = Logger.SILENT,
   ) {
-    super(httpClient, EtherscanClient.API_URL, apiKey, minTimestamp, logger)
+    super(
+      httpClient,
+      EtherscanClient.API_URL,
+      apiKey,
+      minTimestamp,
+      unsupportedMethods,
+      logger,
+    )
   }
 
   getChainId(): ChainId {


### PR DESCRIPTION
Resolves L2B-2747

The previous solution was to treat an error from Etherscan as inability to perform a given method. But sometimes Etherscan like endpoints just fail and not because they do not support a called method. This in turn caused chaos on our Update Monitor where every hour at least one call failed and the diffs where flooding the discord channel because it didn't refetch the information like it should.

Now you have the ability to specify that a given Etherscan like endpoint does not support some method. This will return undefined and the caller has to handle the possibility of that happening.