### PR TITLE
Align description and fix color in the help menu

### DIFF
--- a/packages/discovery/src/cli/usage.ts
+++ b/packages/discovery/src/cli/usage.ts
@@ -7,7 +7,7 @@ const usage = `Usage:
     yarn discover [chain] [project] --dev ........... run on the same block number as in .json
     yarn invert [chain] [project] ................... print addresses and their functions
     yarn invert [chain] [project] --mermaid ......... print mermaid graph markup
-    yarn discover:single [chain] [address]........... run a discovery on the address (no config needed, useful for experimenting)
+    yarn discover:single [chain] [address] .......... run a discovery on the address (no config needed, useful for experimenting)
     yarn <start|discover> --help .................... display this message
 
     supported chains: checkout config.discovery.ts

--- a/packages/discovery/src/cli/usage.ts
+++ b/packages/discovery/src/cli/usage.ts
@@ -3,12 +3,12 @@ import chalk from 'chalk'
 const usage = `Usage:
     yarn start ...................................... run the server application
     yarn discover [chain] [project] ................. run discovery on a specific system
-    yarn discover [chain] [project] --dry-run ..... check simulated discovery bot output
-    yarn discover [chain] [project] --dev ..... run on the same block number as in .json
-    yarn invert [chain] [project] ..................... print addresses and their functions
-    yarn invert [chain] [project] --mermaid .................... print mermaid graph markup
-    yarn discover:single [chain] [address]........ run a discovery on the address (no config needed, useful for experimenting)
-    yarn <start|discover> --help .......................... display this message
+    yarn discover [chain] [project] --dry-run ....... check simulated discovery bot output
+    yarn discover [chain] [project] --dev ........... run on the same block number as in .json
+    yarn invert [chain] [project] ................... print addresses and their functions
+    yarn invert [chain] [project] --mermaid ......... print mermaid graph markup
+    yarn discover:single [chain] [address]........... run a discovery on the address (no config needed, useful for experimenting)
+    yarn <start|discover> --help .................... display this message
 
     supported chains: checkout config.discovery.ts
 `


### PR DESCRIPTION
When no arguments are provided discovery prints a usage menu. It shows a possible command and a description of what that command does. That description over time got unaligned so this PR fixes that. Also one command did not colorize correctly because the regex didn't pass so that is also fixed.