### PR TITLE
Fix default retry strategy unexpected attempts reset

### DIFF
--- a/packages/example/src/Application.ts
+++ b/packages/example/src/Application.ts
@@ -91,11 +91,12 @@ function createMainModule(config: Config, logger: Logger): Module | undefined {
   const balanceRepository = new BalanceRepository()
   const tvlRepository = new TvlRepository()
 
-  BaseIndexer.DEFAULT_RETRY_STRATEGY = Retries.exponentialBackOff({
-    initialTimeoutMs: 100,
-    maxAttempts: 10,
-    maxTimeoutMs: 60 * 1000,
-  })
+  BaseIndexer.GET_DEFAULT_RETRY_STRATEGY = () =>
+    Retries.exponentialBackOff({
+      initialTimeoutMs: 100,
+      maxAttempts: 10,
+      maxTimeoutMs: 60 * 1000,
+    })
 
   const fakeClockIndexer = new FakeClockIndexer(logger)
   const blockNumberIndexer = new BlockNumberIndexer(

--- a/packages/example/src/indexers/BlockNumberIndexer.ts
+++ b/packages/example/src/indexers/BlockNumberIndexer.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@l2beat/backend-tools'
-import { ChildIndexer, Retries } from '@l2beat/uif'
+import { ChildIndexer } from '@l2beat/uif'
 import { setTimeout } from 'timers/promises'
 
 import { BlockNumberRepository } from '../repositories/BlockNumberRepository'
@@ -11,12 +11,7 @@ export class BlockNumberIndexer extends ChildIndexer {
     fakeClockIndexer: FakeClockIndexer,
     private readonly blockNumberRepository: BlockNumberRepository,
   ) {
-    super(logger, [fakeClockIndexer], {
-      updateRetryStrategy: Retries.exponentialBackOff({
-        initialTimeoutMs: 100,
-        maxAttempts: 10,
-      }),
-    })
+    super(logger, [fakeClockIndexer])
   }
 
   override async update(from: number, targetHeight: number): Promise<number> {

--- a/packages/uif/CHANGELOG.md
+++ b/packages/uif/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/uif
 
+## 0.2.2
+
+### Patch Changes
+
+- Fix retry strategies forgetting number of attempts
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/uif/package.json
+++ b/packages/uif/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/uif",
   "description": "Universal Indexer Framework.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "repository": "https://github.com/l2beat/tools",
   "bugs": {


### PR DESCRIPTION
Resolves L2B-2820

### Context

Because `DEFAULT_RETRY_STRATEGY` was a static field on `BaseIndexer`, the functions were shared between all the Indexers. In particular the `clear` function was shared, which caused the memoizes `attempts` value to reset for **ALL THE INDEXERS IN THE SYSTEM**. This PR changes the static field to a static method which fixes this issue.