### PR TITLE
Add reorg protection to ProviderWithCache, based on safe depth

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.17.0
+
+### Minor Changes
+
+- Add optional support for reorg cache protection via safe depth
+
 ## 0.16.2
 
 ### Patch Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/discovery/provider/ProviderWithCache.test.ts
+++ b/packages/discovery/src/discovery/provider/ProviderWithCache.test.ts
@@ -41,7 +41,7 @@ describe('ProviderWithCache', () => {
     })
 
     const blockNumber = undefined
-    const resultCached = await providerWithCache.cacheOrFetch(
+    const result = await providerWithCache.cacheOrFetch(
       'mockCachedKey',
       blockNumber,
       async () => 'mockNotCachedValue',
@@ -49,7 +49,7 @@ describe('ProviderWithCache', () => {
       (value) => value,
     )
 
-    expect(resultCached).toEqual('mockCachedValue')
+    expect(result).toEqual('mockCachedValue')
     expect(mockCache.get).toHaveBeenCalledWith('mockCachedKey')
     expect(mockCache.set).toHaveBeenCalledTimes(0)
   })
@@ -61,7 +61,7 @@ describe('ProviderWithCache', () => {
     })
 
     const blockNumber = 1000
-    const resultCached = await providerWithCache.cacheOrFetch(
+    const result = await providerWithCache.cacheOrFetch(
       'mockCachedKey',
       blockNumber,
       async () => 'mockNotCachedValue',
@@ -69,7 +69,7 @@ describe('ProviderWithCache', () => {
       (value) => value,
     )
 
-    expect(resultCached).toEqual('mockCachedValue')
+    expect(result).toEqual('mockCachedValue')
     expect(mockCache.get).toHaveBeenCalledWith('mockCachedKey')
     expect(mockCache.set).toHaveBeenCalledTimes(0)
   })
@@ -81,7 +81,7 @@ describe('ProviderWithCache', () => {
     })
 
     const blockNumber = undefined
-    const resultCached = await providerWithCache.cacheOrFetch(
+    const result = await providerWithCache.cacheOrFetch(
       'mockNotCachedKey',
       blockNumber,
       async () => 'mockNotCachedValue',
@@ -89,7 +89,7 @@ describe('ProviderWithCache', () => {
       (value) => value,
     )
 
-    expect(resultCached).toEqual('mockNotCachedValue')
+    expect(result).toEqual('mockNotCachedValue')
     expect(mockCache.set).toHaveBeenCalledWith(
       'mockNotCachedKey',
       'mockNotCachedValue',
@@ -105,7 +105,7 @@ describe('ProviderWithCache', () => {
     })
 
     const blockNumber = 1000
-    const resultCached = await providerWithCache.cacheOrFetch(
+    const result = await providerWithCache.cacheOrFetch(
       'mockNotCachedKey',
       blockNumber,
       async () => 'mockNotCachedValue',
@@ -113,7 +113,7 @@ describe('ProviderWithCache', () => {
       (value) => value,
     )
 
-    expect(resultCached).toEqual('mockNotCachedValue')
+    expect(result).toEqual('mockNotCachedValue')
     expect(mockCache.set).toHaveBeenCalledWith(
       'mockNotCachedKey',
       'mockNotCachedValue',
@@ -129,7 +129,7 @@ describe('ProviderWithCache', () => {
     })
 
     const blockNumber = 900
-    const resultCached = await providerWithCache.cacheOrFetch(
+    const result = await providerWithCache.cacheOrFetch(
       'mockNotCachedKey',
       blockNumber,
       async () => 'mockNotCachedValue',
@@ -137,7 +137,7 @@ describe('ProviderWithCache', () => {
       (value) => value,
     )
 
-    expect(resultCached).toEqual('mockNotCachedValue')
+    expect(result).toEqual('mockNotCachedValue')
     expect(mockCache.get).toHaveBeenCalledWith('mockNotCachedKey')
     expect(mockCache.set).toHaveBeenCalledWith(
       'mockNotCachedKey',
@@ -154,7 +154,7 @@ describe('ProviderWithCache', () => {
     })
 
     const blockNumber = 901
-    const resultCached = await providerWithCache.cacheOrFetch(
+    const result = await providerWithCache.cacheOrFetch(
       'mockNotCachedKey',
       blockNumber,
       async () => 'mockNotCachedValue',
@@ -162,7 +162,7 @@ describe('ProviderWithCache', () => {
       (value) => value,
     )
 
-    expect(resultCached).toEqual('mockNotCachedValue')
+    expect(result).toEqual('mockNotCachedValue')
     expect(mockCache.get).toHaveBeenCalledWith('mockNotCachedKey')
     expect(mockCache.set).toHaveBeenCalledTimes(0)
   })

--- a/packages/discovery/src/discovery/provider/ProviderWithCache.test.ts
+++ b/packages/discovery/src/discovery/provider/ProviderWithCache.test.ts
@@ -1,0 +1,169 @@
+import { expect, mockFn, mockObject } from 'earl'
+import { providers } from 'ethers'
+
+import { ChainId } from '../../utils/ChainId'
+import { EtherscanLikeClient } from '../../utils/EtherscanLikeClient'
+import { DiscoveryLogger } from '../DiscoveryLogger'
+import { DiscoveryCache, ProviderWithCache } from './ProviderWithCache'
+
+function setupProviderWithMockCache(values: {
+  curBlockNumber: number
+  reorgSafeDepth: number | undefined
+}) {
+  const mockCache = mockObject<DiscoveryCache>({
+    set: mockFn().resolvesTo(undefined),
+    get: mockFn()
+      .given('mockCachedKey')
+      .resolvesToOnce('mockCachedValue')
+      .given('mockNotCachedKey')
+      .resolvesToOnce(undefined),
+  })
+  const mockProvider = mockObject<providers.Provider>({
+    getBlockNumber: mockFn().resolvesTo(values.curBlockNumber),
+  })
+  const providerWithCache = new ProviderWithCache(
+    mockProvider,
+    mockObject<EtherscanLikeClient>({}),
+    DiscoveryLogger.SILENT,
+    ChainId.ETHEREUM,
+    mockCache,
+    undefined,
+    values.reorgSafeDepth,
+  )
+  return { providerWithCache, mockCache }
+}
+
+describe('ProviderWithCache', () => {
+  it('works when reorgSafeDepth and blockNumber is undefined, value cached', async () => {
+    const { providerWithCache, mockCache } = setupProviderWithMockCache({
+      curBlockNumber: 1000,
+      reorgSafeDepth: undefined,
+    })
+
+    const blockNumber = undefined
+    const resultCached = await providerWithCache.cacheOrFetch(
+      'mockCachedKey',
+      blockNumber,
+      async () => 'mockNotCachedValue',
+      (value) => value,
+      (value) => value,
+    )
+
+    expect(resultCached).toEqual('mockCachedValue')
+    expect(mockCache.get).toHaveBeenCalledWith('mockCachedKey')
+    expect(mockCache.set).toHaveBeenCalledTimes(0)
+  })
+
+  it('works when reorgSafeDepth is undefined, value cached', async () => {
+    const { providerWithCache, mockCache } = setupProviderWithMockCache({
+      curBlockNumber: 1000,
+      reorgSafeDepth: undefined,
+    })
+
+    const blockNumber = 1000
+    const resultCached = await providerWithCache.cacheOrFetch(
+      'mockCachedKey',
+      blockNumber,
+      async () => 'mockNotCachedValue',
+      (value) => value,
+      (value) => value,
+    )
+
+    expect(resultCached).toEqual('mockCachedValue')
+    expect(mockCache.get).toHaveBeenCalledWith('mockCachedKey')
+    expect(mockCache.set).toHaveBeenCalledTimes(0)
+  })
+
+  it('works when reorgSafeDepth and blockNumber is undefined, value not cached', async () => {
+    const { providerWithCache, mockCache } = setupProviderWithMockCache({
+      curBlockNumber: 1000,
+      reorgSafeDepth: undefined,
+    })
+
+    const blockNumber = undefined
+    const resultCached = await providerWithCache.cacheOrFetch(
+      'mockNotCachedKey',
+      blockNumber,
+      async () => 'mockNotCachedValue',
+      (value) => value,
+      (value) => value,
+    )
+
+    expect(resultCached).toEqual('mockNotCachedValue')
+    expect(mockCache.set).toHaveBeenCalledWith(
+      'mockNotCachedKey',
+      'mockNotCachedValue',
+      1,
+      blockNumber,
+    )
+  })
+
+  it('works when reorgSafeDepth is undefined, value not cached', async () => {
+    const { providerWithCache, mockCache } = setupProviderWithMockCache({
+      curBlockNumber: 1000,
+      reorgSafeDepth: undefined,
+    })
+
+    const blockNumber = 1000
+    const resultCached = await providerWithCache.cacheOrFetch(
+      'mockNotCachedKey',
+      blockNumber,
+      async () => 'mockNotCachedValue',
+      (value) => value,
+      (value) => value,
+    )
+
+    expect(resultCached).toEqual('mockNotCachedValue')
+    expect(mockCache.set).toHaveBeenCalledWith(
+      'mockNotCachedKey',
+      'mockNotCachedValue',
+      1,
+      blockNumber,
+    )
+  })
+
+  it('sets cache when reorgSafeDepth not crossed', async () => {
+    const { providerWithCache, mockCache } = setupProviderWithMockCache({
+      curBlockNumber: 1000,
+      reorgSafeDepth: 100,
+    })
+
+    const blockNumber = 900
+    const resultCached = await providerWithCache.cacheOrFetch(
+      'mockNotCachedKey',
+      blockNumber,
+      async () => 'mockNotCachedValue',
+      (value) => value,
+      (value) => value,
+    )
+
+    expect(resultCached).toEqual('mockNotCachedValue')
+    expect(mockCache.get).toHaveBeenCalledWith('mockNotCachedKey')
+    expect(mockCache.set).toHaveBeenCalledWith(
+      'mockNotCachedKey',
+      'mockNotCachedValue',
+      1,
+      blockNumber,
+    )
+  })
+
+  it("doesn't cache when reorgSafeDepth is crossed", async () => {
+    const { providerWithCache, mockCache } = setupProviderWithMockCache({
+      curBlockNumber: 1000,
+      reorgSafeDepth: 100,
+    })
+
+    const blockNumber = 901
+    const resultCached = await providerWithCache.cacheOrFetch(
+      'mockNotCachedKey',
+      blockNumber,
+      async () => 'mockNotCachedValue',
+      (value) => value,
+      (value) => value,
+    )
+
+    expect(resultCached).toEqual('mockNotCachedValue')
+    expect(mockCache.get).toHaveBeenCalledWith('mockNotCachedKey')
+    expect(mockCache.set).toHaveBeenCalledTimes(0)
+  })
+})

--- a/packages/discovery/src/discovery/provider/ProviderWithCache.ts
+++ b/packages/discovery/src/discovery/provider/ProviderWithCache.ts
@@ -72,8 +72,9 @@ export class ProviderWithCache extends DiscoveryProvider {
     return result
   }
 
-  private async isBlockNumberReorgSafe(
+  public async isBlockNumberReorgSafe(
     blockNumber: number | undefined,
+    curTimeMsOverride?: number, // for testing
   ): Promise<boolean> {
     if (blockNumber === undefined) {
       return true
@@ -83,15 +84,16 @@ export class ProviderWithCache extends DiscoveryProvider {
       return true
     }
 
+    const curTime = curTimeMsOverride ?? Date.now()
     const timeSinceLastCurBlockCheck =
-      Date.now() - (this.lastCurBlockCheckTime ?? 0)
+      curTime - (this.lastCurBlockCheckTime ?? 0)
 
     if (
       this.curBlockNumber === undefined ||
-      timeSinceLastCurBlockCheck > CUR_BLOCK_CHECK_INTERVAL_SECONDS * 1000
+      timeSinceLastCurBlockCheck >= CUR_BLOCK_CHECK_INTERVAL_SECONDS * 1000
     ) {
       this.curBlockNumber = await super.getBlockNumber()
-      this.lastCurBlockCheckTime = Date.now()
+      this.lastCurBlockCheckTime = curTime
     }
 
     const reorgSafeBlockNumber = this.curBlockNumber - this.reorgSafeDepth

--- a/packages/discovery/src/discovery/provider/ProviderWithCache.ts
+++ b/packages/discovery/src/discovery/provider/ProviderWithCache.ts
@@ -24,7 +24,15 @@ export interface DiscoveryCache {
   get(key: string): Promise<string | undefined>
 }
 
+// If reorgSafeDepth is provided, we need to refresh
+// current block number from time to time to calculate
+// which block numbers are safe to cache.
+const CUR_BLOCK_CHECK_INTERVAL_SECONDS = 60
+
 export class ProviderWithCache extends DiscoveryProvider {
+  private curBlockNumber?: number
+  private lastCurBlockCheckTime?: number
+
   constructor(
     provider: providers.Provider | RateLimitedProvider,
     etherscanLikeClient: EtherscanLikeClient,
@@ -32,11 +40,12 @@ export class ProviderWithCache extends DiscoveryProvider {
     private readonly chainId: ChainId,
     private readonly cache: DiscoveryCache,
     getLogsMaxRange?: number,
+    readonly reorgSafeDepth?: number,
   ) {
     super(provider, etherscanLikeClient, logger, getLogsMaxRange)
   }
 
-  private async cacheOrFetch<R>(
+  public async cacheOrFetch<R>(
     key: string,
     blockNumber: number | undefined,
     fetch: () => Promise<R>,
@@ -49,14 +58,44 @@ export class ProviderWithCache extends DiscoveryProvider {
     }
 
     const result = await fetch()
-    await this.cache.set(
-      key,
-      toCache(result),
-      this.chainId.valueOf(),
-      blockNumber,
-    )
+
+    const isReorgSafe = await this.isBlockNumberReorgSafe(blockNumber)
+    if (isReorgSafe) {
+      await this.cache.set(
+        key,
+        toCache(result),
+        this.chainId.valueOf(),
+        blockNumber,
+      )
+    }
 
     return result
+  }
+
+  private async isBlockNumberReorgSafe(
+    blockNumber: number | undefined,
+  ): Promise<boolean> {
+    if (blockNumber === undefined) {
+      return true
+    }
+
+    if (this.reorgSafeDepth === undefined) {
+      return true
+    }
+
+    const timeSinceLastCurBlockCheck =
+      Date.now() - (this.lastCurBlockCheckTime ?? 0)
+
+    if (
+      this.curBlockNumber === undefined ||
+      timeSinceLastCurBlockCheck > CUR_BLOCK_CHECK_INTERVAL_SECONDS * 1000
+    ) {
+      this.curBlockNumber = await super.getBlockNumber()
+      this.lastCurBlockCheckTime = Date.now()
+    }
+
+    const reorgSafeBlockNumber = this.curBlockNumber - this.reorgSafeDepth
+    return blockNumber <= reorgSafeBlockNumber
   }
 
   buildKey(invocation: string, params: { toString: () => string }[]): string {


### PR DESCRIPTION
Resolves L2B-2733

Reorg protection is optional. If `safeReorgDepth` is not passed to `ProviderWithCache`, it behaves like always and caches everything. Reorg protection needs to be implemented by the caller.

If `safeReorgDepth` is provided, `ProviderWithCache` will not cache anything (that provides relevant blockNumber) when it's too close to current block number (which is refreshed every minute).
