### PR TITLE
Use Multicall for SimpleStorageHandler

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.18.0
+
+### Minor Changes
+
+- Add multicall support and use multicall for SimpleStorageHandler
+
 ## 0.17.2
 
 ### Patch Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/cli.ts
+++ b/packages/discovery/src/cli.ts
@@ -61,6 +61,7 @@ async function discover(
     await dryRunDiscovery(
       provider,
       etherscanClient,
+      config.chain.multicall,
       configReader,
       discoverConfig,
     )
@@ -71,7 +72,13 @@ async function discover(
   logger.info('Starting discovery...\n')
   logger.info(`Project: ${discoverConfig.project}`)
   logger.info(`Chain: ${ChainId.getName(discoverConfig.chainId)}\n`)
-  await runDiscovery(provider, etherscanClient, configReader, discoverConfig)
+  await runDiscovery(
+    provider,
+    etherscanClient,
+    config.chain.multicall,
+    configReader,
+    discoverConfig,
+  )
 }
 
 async function invert(

--- a/packages/discovery/src/config/config.discovery.ts
+++ b/packages/discovery/src/config/config.discovery.ts
@@ -2,6 +2,8 @@ import { getEnv } from '@l2beat/backend-tools'
 import { config as dotenv } from 'dotenv'
 
 import { CliParameters } from '../cli/getCliParameters'
+import { multicallConfig } from '../discovery/provider/multicall/MulticallConfig'
+import { MulticallConfig } from '../discovery/provider/multicall/types'
 import { ChainId } from '../utils/ChainId'
 import { EthereumAddress } from '../utils/EthereumAddress'
 import { EtherscanUnsupportedMethods } from '../utils/EtherscanLikeClient'
@@ -57,6 +59,7 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
         rpcGetLogsMaxRange: env.optionalInteger(
           'DISCOVERY_ETHEREUM_RPC_GETLOGS_MAX_RANGE',
         ),
+        multicall: multicallConfig.ethereum,
         etherscanApiKey: env.string('DISCOVERY_ETHEREUM_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.etherscan.io/api',
       }
@@ -67,6 +70,7 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
         rpcGetLogsMaxRange: env.optionalInteger(
           'DISCOVERY_ARBITRUM_RPC_GETLOGS_MAX_RANGE',
         ),
+        multicall: multicallConfig.arbitrum,
         etherscanApiKey: env.string('DISCOVERY_ARBITRUM_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.arbiscan.io/api',
       }
@@ -77,6 +81,7 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
         rpcGetLogsMaxRange: env.optionalInteger(
           'DISCOVERY_OPTIMISM_RPC_GETLOGS_MAX_RANGE',
         ),
+        multicall: multicallConfig.optimism,
         etherscanApiKey: env.string('DISCOVERY_OPTIMISM_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api-optimistic.etherscan.io/api',
       }
@@ -87,6 +92,7 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
         rpcGetLogsMaxRange: env.optionalInteger(
           'DISCOVERY_POLYGON_POS_RPC_GETLOGS_MAX_RANGE',
         ),
+        multicall: multicallConfig.polygon_pos,
         etherscanApiKey: env.string('DISCOVERY_POLYGON_POS_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.polygonscan.com/api',
       }
@@ -97,6 +103,7 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
         rpcGetLogsMaxRange: env.optionalInteger(
           'DISCOVERY_BSC_RPC_GETLOGS_MAX_RANGE',
         ),
+        multicall: multicallConfig.bsc,
         etherscanApiKey: env.string('DISCOVERY_BSC_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.bscscan.com/api',
       }
@@ -107,6 +114,7 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
         rpcGetLogsMaxRange: env.optionalInteger(
           'DISCOVERY_AVALANCHE_RPC_GETLOGS_MAX_RANGE',
         ),
+        multicall: multicallConfig.avalanche,
         etherscanApiKey: env.string('DISCOVERY_AVALANCHE_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.snowtrace.io/api',
       }
@@ -117,6 +125,7 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
         rpcGetLogsMaxRange: env.optionalInteger(
           'DISCOVERY_CELO_RPC_GETLOGS_MAX_RANGE',
         ),
+        multicall: multicallConfig.celo,
         etherscanApiKey: env.string('DISCOVERY_CELO_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.celoscan.io/api',
         etherscanUnsupported: {
@@ -130,6 +139,7 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
         rpcGetLogsMaxRange: env.optionalInteger(
           'DISCOVERY_LINEA_RPC_GETLOGS_MAX_RANGE',
         ),
+        multicall: multicallConfig.linea,
         etherscanApiKey: env.string('DISCOVERY_LINEA_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.lineascan.build/api',
       }
@@ -140,6 +150,7 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
         rpcGetLogsMaxRange: env.optionalInteger(
           'DISCOVERY_BASE_RPC_GETLOGS_MAX_RANGE',
         ),
+        multicall: multicallConfig.base,
         etherscanApiKey: env.string('DISCOVERY_BASE_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.basescan.org/api',
       }
@@ -150,6 +161,7 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
         rpcGetLogsMaxRange: env.optionalInteger(
           'DISCOVERY_POLYGON_ZKEVM_RPC_GETLOGS_MAX_RANGE',
         ),
+        multicall: multicallConfig.polygon_zkevm,
         etherscanApiKey: env.string(
           'DISCOVERY_POLYGON_ZKEVM_ETHERSCAN_API_KEY',
         ),
@@ -162,6 +174,7 @@ function getChainConfig(chainId: ChainId): DiscoveryChainConfig {
         rpcGetLogsMaxRange: env.optionalInteger(
           'DISCOVERY_GNOSIS_RPC_GETLOGS_MAX_RANGE',
         ),
+        multicall: multicallConfig.gnosis,
         etherscanApiKey: env.string('DISCOVERY_GNOSIS_ETHERSCAN_API_KEY'),
         etherscanUrl: 'https://api.gnosisscan.io/api',
       }
@@ -199,6 +212,7 @@ export interface DiscoveryChainConfig {
   chainId: ChainId
   rpcUrl: string
   rpcGetLogsMaxRange?: number
+  multicall: MulticallConfig
   etherscanApiKey: string
   etherscanUrl: string
   etherscanUnsupported?: EtherscanUnsupportedMethods

--- a/packages/discovery/src/discovery/engine/discover.ts
+++ b/packages/discovery/src/discovery/engine/discover.ts
@@ -3,6 +3,8 @@ import { DiscoveryConfig } from '../config/DiscoveryConfig'
 import { DiscoveryLogger } from '../DiscoveryLogger'
 import { HandlerExecutor } from '../handlers/HandlerExecutor'
 import { DiscoveryProvider } from '../provider/DiscoveryProvider'
+import { MulticallClient } from '../provider/multicall/MulticallClient'
+import { MulticallConfig } from '../provider/multicall/types'
 import { ProxyDetector } from '../proxies/ProxyDetector'
 import { SourceCodeService } from '../source/SourceCodeService'
 import { DiscoveryEngine } from './DiscoveryEngine'
@@ -10,12 +12,14 @@ import { DiscoveryEngine } from './DiscoveryEngine'
 export async function discover(
   provider: DiscoveryProvider,
   config: DiscoveryConfig,
+  multicallConfig: MulticallConfig,
   logger: DiscoveryLogger,
   blockNumber: number,
 ): Promise<Analysis[]> {
   const proxyDetector = new ProxyDetector(provider, logger)
   const sourceCodeService = new SourceCodeService(provider)
-  const handlerExecutor = new HandlerExecutor(provider, logger)
+  const multicallClient = new MulticallClient(provider, multicallConfig)
+  const handlerExecutor = new HandlerExecutor(provider, multicallClient, logger)
   const addressAnalyzer = new AddressAnalyzer(
     provider,
     proxyDetector,

--- a/packages/discovery/src/discovery/handlers/Handler.ts
+++ b/packages/discovery/src/discovery/handlers/Handler.ts
@@ -15,7 +15,7 @@ export interface HandlerResult {
   ignoreRelative?: boolean
 }
 
-export interface ClassicHandler {
+interface BaseHandler {
   field: string
   dependencies: string[]
   logger?: DiscoveryLogger
@@ -27,7 +27,11 @@ export interface ClassicHandler {
   ): Promise<HandlerResult>
 }
 
-export interface MulticallableHandler extends ClassicHandler {
+export interface ClassicHandler extends BaseHandler {
+  multicallable?: false
+}
+
+export interface MulticallableHandler extends BaseHandler {
   multicallable: true
   encode(
     address: EthereumAddress,

--- a/packages/discovery/src/discovery/handlers/Handler.ts
+++ b/packages/discovery/src/discovery/handlers/Handler.ts
@@ -3,6 +3,10 @@ import { ContractValue } from '@l2beat/discovery-types'
 import { EthereumAddress } from '../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../DiscoveryLogger'
 import { DiscoveryProvider } from '../provider/DiscoveryProvider'
+import {
+  MulticallRequest,
+  MulticallResponse,
+} from '../provider/multicall/types'
 
 export interface HandlerResult {
   field: string
@@ -11,7 +15,20 @@ export interface HandlerResult {
   ignoreRelative?: boolean
 }
 
-export interface Handler {
+export interface MulticallableHandler {
+  type: 'multicallable'
+  field: string
+  dependencies: string[]
+  logger?: DiscoveryLogger
+  encode(
+    address: EthereumAddress,
+    previousResults: Record<string, HandlerResult | undefined>,
+  ): MulticallRequest[]
+  decode: (result: MulticallResponse[]) => HandlerResult
+}
+
+export interface ClassicHandler {
+  type?: 'classic'
   field: string
   dependencies: string[]
   logger?: DiscoveryLogger
@@ -22,3 +39,5 @@ export interface Handler {
     previousResults: Record<string, HandlerResult | undefined>,
   ): Promise<HandlerResult>
 }
+
+export type Handler = MulticallableHandler | ClassicHandler

--- a/packages/discovery/src/discovery/handlers/Handler.ts
+++ b/packages/discovery/src/discovery/handlers/Handler.ts
@@ -15,20 +15,7 @@ export interface HandlerResult {
   ignoreRelative?: boolean
 }
 
-export interface MulticallableHandler {
-  type: 'multicallable'
-  field: string
-  dependencies: string[]
-  logger?: DiscoveryLogger
-  encode(
-    address: EthereumAddress,
-    previousResults: Record<string, HandlerResult | undefined>,
-  ): MulticallRequest[]
-  decode: (result: MulticallResponse[]) => HandlerResult
-}
-
 export interface ClassicHandler {
-  type?: 'classic'
   field: string
   dependencies: string[]
   logger?: DiscoveryLogger
@@ -38,6 +25,15 @@ export interface ClassicHandler {
     blockNumber: number,
     previousResults: Record<string, HandlerResult | undefined>,
   ): Promise<HandlerResult>
+}
+
+export interface MulticallableHandler extends ClassicHandler {
+  multicallable: true
+  encode(
+    address: EthereumAddress,
+    previousResults: Record<string, HandlerResult | undefined>,
+  ): MulticallRequest[]
+  decode: (result: MulticallResponse[]) => HandlerResult
 }
 
 export type Handler = MulticallableHandler | ClassicHandler

--- a/packages/discovery/src/discovery/handlers/HandlerExecutor.ts
+++ b/packages/discovery/src/discovery/handlers/HandlerExecutor.ts
@@ -4,6 +4,7 @@ import { EthereumAddress } from '../../utils/EthereumAddress'
 import { ContractOverrides } from '../config/DiscoveryOverrides'
 import { DiscoveryLogger } from '../DiscoveryLogger'
 import { DiscoveryProvider } from '../provider/DiscoveryProvider'
+import { MulticallClient } from '../provider/multicall/MulticallClient'
 import { executeHandlers } from './executeHandlers'
 import { getHandlers } from './getHandlers'
 import { getValuesAndErrors } from './getValuesAndErrors'
@@ -12,6 +13,7 @@ import { HandlerResult } from './Handler'
 export class HandlerExecutor {
   constructor(
     private readonly provider: DiscoveryProvider,
+    private readonly multicallClient: MulticallClient,
     private readonly logger: DiscoveryLogger,
   ) {}
 
@@ -28,6 +30,7 @@ export class HandlerExecutor {
     const handlers = getHandlers(abi, overrides, this.logger)
     const results = await executeHandlers(
       this.provider,
+      this.multicallClient,
       handlers,
       address,
       blockNumber,

--- a/packages/discovery/src/discovery/handlers/executeHandlers.test.ts
+++ b/packages/discovery/src/discovery/handlers/executeHandlers.test.ts
@@ -4,16 +4,19 @@ import { Bytes } from '../../utils/Bytes'
 import { EthereumAddress } from '../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../DiscoveryLogger'
 import { DiscoveryProvider } from '../provider/DiscoveryProvider'
+import { MulticallClient } from '../provider/multicall/MulticallClient'
 import { executeHandlers } from './executeHandlers'
-import { Handler, HandlerResult } from './Handler'
+import { ClassicHandler, HandlerResult } from './Handler'
 import { StorageHandler } from './user/StorageHandler'
+import { SimpleMethodHandler } from './system/SimpleMethodHandler'
+import { ArrayHandler } from './user/ArrayHandler'
 
 describe(executeHandlers.name, () => {
   const BLOCK_NUMBER = 1234
 
   function providerWithStorage(layout: Record<string, number>) {
     return mockObject<DiscoveryProvider>({
-      async getStorage(address, slot) {
+      async getStorage(_, slot) {
         const number = Number(BigInt(slot.toString()))
         const value = layout[number]
         return Bytes.fromHex(value!.toString(16).padStart(64, '0'))
@@ -28,6 +31,7 @@ describe(executeHandlers.name, () => {
     })
     const values = await executeHandlers(
       provider,
+      mockObject<MulticallClient>(),
       [
         new StorageHandler(
           'foo',
@@ -59,6 +63,7 @@ describe(executeHandlers.name, () => {
     })
     const values = await executeHandlers(
       provider,
+      mockObject<MulticallClient>(),
       [
         new StorageHandler(
           'xxx',
@@ -104,6 +109,7 @@ describe(executeHandlers.name, () => {
     })
     const values = await executeHandlers(
       provider,
+      mockObject<MulticallClient>(),
       [
         new StorageHandler(
           'aab',
@@ -174,6 +180,7 @@ describe(executeHandlers.name, () => {
     const provider = mockObject<DiscoveryProvider>()
     const promise = executeHandlers(
       provider,
+      mockObject<MulticallClient>(),
       [
         new StorageHandler(
           'a',
@@ -192,6 +199,7 @@ describe(executeHandlers.name, () => {
     const provider = mockObject<DiscoveryProvider>()
     const promise = executeHandlers(
       provider,
+      mockObject<MulticallClient>(),
       [
         new StorageHandler(
           'a',
@@ -210,6 +218,7 @@ describe(executeHandlers.name, () => {
     const provider = mockObject<DiscoveryProvider>()
     const promise = executeHandlers(
       provider,
+      mockObject<MulticallClient>(),
       [
         new StorageHandler(
           'a',
@@ -230,7 +239,7 @@ describe(executeHandlers.name, () => {
   })
 
   it('handles handlers with errors', async () => {
-    class FunkyHandler implements Handler {
+    class FunkyHandler implements ClassicHandler {
       dependencies: string[] = []
       field = 'foo'
       logger = DiscoveryLogger.SILENT
@@ -242,11 +251,123 @@ describe(executeHandlers.name, () => {
     const provider = mockObject<DiscoveryProvider>()
     const values = await executeHandlers(
       provider,
+      mockObject<MulticallClient>(),
       [new FunkyHandler()],
       EthereumAddress.random(),
       BLOCK_NUMBER,
       DiscoveryLogger.SILENT,
     )
     expect<unknown[]>(values).toEqual([{ field: 'foo', error: 'oops' }])
+  })
+
+  it('handles multicallable handlers', async () => {
+    const ADDRESS = EthereumAddress.random()
+    const method = 'function foo() external view returns (uint256)'
+    const selector = 'c2985578'
+    const provider = providerWithStorage({
+      1: 123,
+    })
+    const multicall = mockObject<MulticallClient>({
+      multicallNamed: async (requests) => {
+        expect(requests).toEqual({
+          foo: [
+            {
+              address: ADDRESS,
+              data: Bytes.fromHex(selector),
+            },
+          ],
+        })
+
+        return {
+          foo: [
+            {
+              success: true,
+              data: Bytes.fromHex('0x' + '12345678'.padStart(64, '0')),
+            },
+          ],
+        }
+      },
+    })
+    const values = await executeHandlers(
+      provider,
+      multicall,
+      [
+        new StorageHandler(
+          'a',
+          { type: 'storage', slot: 1, returnType: 'number' },
+          DiscoveryLogger.SILENT,
+        ),
+        new SimpleMethodHandler(method, DiscoveryLogger.SILENT),
+      ],
+      ADDRESS,
+      BLOCK_NUMBER,
+      DiscoveryLogger.SILENT,
+    )
+
+    expect(values).toEqual([
+      { field: 'foo', value: 0x12345678 },
+      { field: 'a', value: 123, ignoreRelative: undefined },
+    ])
+  })
+
+  it('handles multicallable handlers with dependencies', async () => {
+    const ADDRESS = EthereumAddress.random()
+    const method = 'function foo() external view returns (uint256)'
+    const selector = 'c2985578'
+    const provider = mockObject<DiscoveryProvider>({
+      async call() {
+        return Bytes.fromHex('0x' + '12345678'.padStart(64, '0'))
+      },
+    })
+    const multicall = mockObject<MulticallClient>({
+      multicallNamed: async (requests) => {
+        expect(requests).toEqual({
+          foo: [
+            {
+              address: ADDRESS,
+              data: Bytes.fromHex(selector),
+            },
+          ],
+        })
+
+        return {
+          foo: [
+            {
+              success: true,
+              data: Bytes.fromHex('0x' + '3'.padStart(64, '0')),
+            },
+          ],
+        }
+      },
+    })
+    const values = await executeHandlers(
+      provider,
+      multicall,
+      [
+        new ArrayHandler(
+          'bar',
+          {
+            type: 'array',
+            method: 'bar',
+            length: '{{ foo }}',
+          },
+          ['function bar(uint256) external view returns (uint256)'],
+          DiscoveryLogger.SILENT,
+        ),
+        new SimpleMethodHandler(method, DiscoveryLogger.SILENT),
+      ],
+      ADDRESS,
+      BLOCK_NUMBER,
+      DiscoveryLogger.SILENT,
+    )
+
+    expect(values).toEqual([
+      { field: 'foo', value: 3 },
+      {
+        field: 'bar',
+        value: [0x12345678, 0x12345678, 0x12345678],
+        ignoreRelative: undefined,
+      },
+    ])
   })
 })

--- a/packages/discovery/src/discovery/handlers/executeHandlers.test.ts
+++ b/packages/discovery/src/discovery/handlers/executeHandlers.test.ts
@@ -7,9 +7,9 @@ import { DiscoveryProvider } from '../provider/DiscoveryProvider'
 import { MulticallClient } from '../provider/multicall/MulticallClient'
 import { executeHandlers } from './executeHandlers'
 import { ClassicHandler, HandlerResult } from './Handler'
-import { StorageHandler } from './user/StorageHandler'
 import { SimpleMethodHandler } from './system/SimpleMethodHandler'
 import { ArrayHandler } from './user/ArrayHandler'
+import { StorageHandler } from './user/StorageHandler'
 
 describe(executeHandlers.name, () => {
   const BLOCK_NUMBER = 1234

--- a/packages/discovery/src/discovery/handlers/executeHandlers.ts
+++ b/packages/discovery/src/discovery/handlers/executeHandlers.ts
@@ -1,22 +1,48 @@
+import { assert } from '@l2beat/backend-tools'
+
 import { EthereumAddress } from '../../utils/EthereumAddress'
 import { getErrorMessage } from '../../utils/getErrorMessage'
 import { DiscoveryLogger } from '../DiscoveryLogger'
 import { DiscoveryProvider } from '../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from './Handler'
+import { MulticallClient } from '../provider/multicall/MulticallClient'
+import { MulticallRequest } from '../provider/multicall/types'
+import { Handler, HandlerResult, MulticallableHandler } from './Handler'
 
 export async function executeHandlers(
   provider: DiscoveryProvider,
+  multicallClient: MulticallClient,
   handlers: Handler[],
   address: EthereumAddress,
   blockNumber: number,
   logger: DiscoveryLogger,
 ): Promise<HandlerResult[]> {
   const results: HandlerResult[] = []
-  const batches = orderByDependencies(handlers)
+
+  const batches = orderByDependenciesWithMulticall(handlers)
   for (const batch of batches) {
     const fields = Object.fromEntries(results.map((r) => [r.field, r]))
+    if (batch.multicallable.length > 0) {
+      const encodedNamedRequests = new Map<string, MulticallRequest[]>()
+      for (const handler of batch.multicallable) {
+        const requests = handler.encode(address, fields)
+        assert(requests)
+        encodedNamedRequests.set(handler.field, requests)
+      }
+      const multicallResults = await multicallClient.multicallNamed(
+        Object.fromEntries(encodedNamedRequests),
+        blockNumber,
+      )
+
+      for (const handler of batch.multicallable) {
+        const encoded = multicallResults[handler.field]
+        assert(encoded)
+        const decoded = handler.decode(encoded)
+        results.push(decoded)
+      }
+    }
+
     const batchResults = await Promise.all(
-      batch.map(async (x) => {
+      batch.nonMulticallable.map(async (x) => {
         try {
           const result = await x.execute(provider, address, blockNumber, fields)
           if (result.error) {
@@ -33,25 +59,36 @@ export async function executeHandlers(
   return results
 }
 
-function orderByDependencies(handlers: Handler[]): Handler[][] {
+function orderByDependenciesWithMulticall(handlers: Handler[]): {
+  multicallable: MulticallableHandler[]
+  nonMulticallable: Handler[]
+}[] {
   const known = new Set<string>()
   const batches = []
   const remaining = new Set(handlers)
   while (remaining.size > 0) {
-    const batch = []
+    const multicallableBatch: MulticallableHandler[] = []
+    const nonMulticallableBatch: Handler[] = []
     for (const handler of remaining) {
       if (handler.dependencies.every((x) => known.has(x))) {
-        batch.push(handler)
+        if (handler.multicallable) {
+          multicallableBatch.push(handler)
+        } else {
+          nonMulticallableBatch.push(handler)
+        }
       }
     }
-    if (batch.length === 0) {
+    if (multicallableBatch.length === 0 && nonMulticallableBatch.length === 0) {
       throw new Error('Impossible to resolve dependencies')
     }
-    for (const handler of batch) {
+    for (const handler of [...multicallableBatch, ...nonMulticallableBatch]) {
       known.add(handler.field)
       remaining.delete(handler)
     }
-    batches.push(batch)
+    batches.push({
+      multicallable: multicallableBatch,
+      nonMulticallable: nonMulticallableBatch,
+    })
   }
   return batches
 }

--- a/packages/discovery/src/discovery/handlers/system/ErrorHandler.ts
+++ b/packages/discovery/src/discovery/handlers/system/ErrorHandler.ts
@@ -1,7 +1,7 @@
 import { getErrorMessage } from '../../../utils/getErrorMessage'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 
-export class ErrorHandler implements Handler {
+export class ErrorHandler implements ClassicHandler {
   readonly dependencies = []
   private readonly errorMessage: string
 

--- a/packages/discovery/src/discovery/handlers/system/LimitedArrayHandler.ts
+++ b/packages/discovery/src/discovery/handlers/system/LimitedArrayHandler.ts
@@ -4,11 +4,11 @@ import { utils } from 'ethers'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 import { callMethod } from '../utils/callMethod'
 import { toFunctionFragment } from '../utils/toFunctionFragment'
 
-export class LimitedArrayHandler implements Handler {
+export class LimitedArrayHandler implements ClassicHandler {
   readonly field: string
   readonly dependencies = []
   private readonly fragment: utils.FunctionFragment

--- a/packages/discovery/src/discovery/handlers/system/SimpleMethodHandler.test.ts
+++ b/packages/discovery/src/discovery/handlers/system/SimpleMethodHandler.test.ts
@@ -4,71 +4,136 @@ import { Bytes } from '../../../utils/Bytes'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
+import { MulticallClient } from '../../provider/multicall/MulticallClient'
 import { SimpleMethodHandler } from './SimpleMethodHandler'
 
 describe(SimpleMethodHandler.name, () => {
   const BLOCK_NUMBER = 1234
 
-  it('can correctly call balanceOf', async () => {
-    const address = EthereumAddress.random()
-    const provider = mockObject<DiscoveryProvider>({
-      async call(passedAddress, data) {
-        expect(passedAddress).toEqual(address)
-        expect(data).toEqual(Bytes.fromHex('0x722713f7'))
-        return Bytes.fromHex(
-          '0x0000000000000000000000000000000000000000000000000000000000000123',
-        )
-      },
+  describe(SimpleMethodHandler.prototype.execute.name, () => {
+    it('can correctly call balanceOf', async () => {
+      const address = EthereumAddress.random()
+      const provider = mockObject<DiscoveryProvider>({
+        async call(passedAddress, data) {
+          expect(passedAddress).toEqual(address)
+          expect(data).toEqual(Bytes.fromHex('0x722713f7'))
+          return Bytes.fromHex(
+            '0x0000000000000000000000000000000000000000000000000000000000000123',
+          )
+        },
+      })
+
+      const handler = new SimpleMethodHandler(
+        'function balanceOf() view returns (uint256)',
+        DiscoveryLogger.SILENT,
+      )
+      expect(handler.field).toEqual('balanceOf')
+
+      const result = await handler.execute(provider, address, BLOCK_NUMBER)
+      expect(result).toEqual({
+        field: 'balanceOf',
+        value: 0x123,
+      })
     })
 
-    const handler = new SimpleMethodHandler(
-      'function balanceOf() view returns (uint256)',
-      DiscoveryLogger.SILENT,
-    )
-    expect(handler.field).toEqual('balanceOf')
+    it('handles a revert', async () => {
+      const handler = new SimpleMethodHandler(
+        'function balanceOf() view returns (uint256)',
+        DiscoveryLogger.SILENT,
+      )
 
-    const result = await handler.execute(provider, address, BLOCK_NUMBER)
-    expect(result).toEqual({
-      field: 'balanceOf',
-      value: 0x123,
+      const provider = mockObject<DiscoveryProvider>({
+        async call() {
+          throw new Error('Error during execution: revert')
+        },
+      })
+      const address = EthereumAddress.random()
+      const result = await handler.execute(provider, address, BLOCK_NUMBER)
+      expect(result).toEqual({
+        field: 'balanceOf',
+        error: 'Execution reverted',
+      })
+    })
+
+    it('handles any other error', async () => {
+      const handler = new SimpleMethodHandler(
+        'function balanceOf() view returns (uint256)',
+        DiscoveryLogger.SILENT,
+      )
+
+      const provider = mockObject<DiscoveryProvider>({
+        async call() {
+          throw new Error('foo bar')
+        },
+      })
+      const address = EthereumAddress.random()
+      const result = await handler.execute(provider, address, BLOCK_NUMBER)
+      expect(result).toEqual({
+        field: 'balanceOf',
+        error: 'foo bar',
+      })
     })
   })
 
-  it('handles a revert', async () => {
-    const handler = new SimpleMethodHandler(
-      'function balanceOf() view returns (uint256)',
-      DiscoveryLogger.SILENT,
-    )
+  describe('multicallable', () => {
+    it('can correctly call balanceOf', async () => {
+      const address = EthereumAddress.random()
+      const multicall = mockObject<MulticallClient>({
+        async multicall() {
+          return [
+            {
+              success: true,
+              data: Bytes.fromHex(
+                '0x0000000000000000000000000000000000000000000000000000000000000123',
+              ),
+            },
+          ]
+        },
+      })
 
-    const provider = mockObject<DiscoveryProvider>({
-      async call() {
-        throw new Error('Error during execution: revert')
-      },
+      const handler = new SimpleMethodHandler(
+        'function balanceOf() view returns (uint256)',
+        DiscoveryLogger.SILENT,
+      )
+      expect(handler.field).toEqual('balanceOf')
+      const encoded = handler.encode(address)
+      expect(encoded).toEqual([
+        {
+          address,
+          data: Bytes.fromHex('0x722713f7'),
+        },
+      ])
+      const response = await multicall.multicall(encoded, BLOCK_NUMBER)
+      const result = handler.decode(response)
+      expect(result).toEqual({
+        field: 'balanceOf',
+        value: 0x123,
+      })
     })
-    const address = EthereumAddress.random()
-    const result = await handler.execute(provider, address, BLOCK_NUMBER)
-    expect(result).toEqual({
-      field: 'balanceOf',
-      error: 'Execution reverted',
-    })
-  })
 
-  it('handles any other error', async () => {
-    const handler = new SimpleMethodHandler(
-      'function balanceOf() view returns (uint256)',
-      DiscoveryLogger.SILENT,
-    )
-
-    const provider = mockObject<DiscoveryProvider>({
-      async call() {
-        throw new Error('foo bar')
-      },
-    })
-    const address = EthereumAddress.random()
-    const result = await handler.execute(provider, address, BLOCK_NUMBER)
-    expect(result).toEqual({
-      field: 'balanceOf',
-      error: 'foo bar',
+    it('handles an error', async () => {
+      const handler = new SimpleMethodHandler(
+        'function balanceOf() view returns (uint256)',
+        DiscoveryLogger.SILENT,
+      )
+      const multicall = mockObject<MulticallClient>({
+        async multicall() {
+          return [
+            {
+              success: false,
+              data: Bytes.EMPTY,
+            },
+          ]
+        },
+      })
+      const address = EthereumAddress.random()
+      const encoded = handler.encode(address)
+      const response = await multicall.multicall(encoded, BLOCK_NUMBER)
+      const result = handler.decode(response)
+      expect(result).toEqual({
+        field: 'balanceOf',
+        error: 'Multicall failed',
+      })
     })
   })
 })

--- a/packages/discovery/src/discovery/handlers/system/SimpleMethodHandler.ts
+++ b/packages/discovery/src/discovery/handlers/system/SimpleMethodHandler.ts
@@ -1,16 +1,26 @@
+import { assert } from '@l2beat/backend-tools'
 import { utils } from 'ethers'
 
+import { Bytes } from '../../../utils/Bytes'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import {
+  MulticallRequest,
+  MulticallResponse,
+} from '../../provider/multicall/types'
+import { HandlerResult, MulticallableHandler } from '../Handler'
 import { callMethod } from '../utils/callMethod'
+import { toContractValue } from '../utils/toContractValue'
 import { toFunctionFragment } from '../utils/toFunctionFragment'
 
-export class SimpleMethodHandler implements Handler {
+export class SimpleMethodHandler implements MulticallableHandler {
+  multicallable = true as const
   readonly field: string
   readonly dependencies = []
+
   private readonly fragment: utils.FunctionFragment
+
   constructor(
     fragment: string | utils.FunctionFragment,
     readonly logger: DiscoveryLogger,
@@ -37,5 +47,38 @@ export class SimpleMethodHandler implements Handler {
       blockNumber,
     )
     return { field: this.field, ...callResult }
+  }
+
+  encode(address: EthereumAddress): MulticallRequest[] {
+    this.logger.logExecution(this.field, [
+      'Encoding for multicall ',
+      this.fragment.name + '()',
+    ])
+    const iface = new utils.Interface([this.fragment])
+    const encoded = iface.encodeFunctionData(this.fragment.name)
+
+    return [{ address, data: Bytes.fromHex(encoded) }]
+  }
+
+  decode(result: MulticallResponse[]): HandlerResult {
+    const response = result[0]
+    assert(response, 'Multicall response not found')
+    if (!response.success) {
+      return { field: this.field, error: 'Multicall failed' }
+    }
+
+    this.logger.logExecution(this.field, [
+      'Decoding from multicall ',
+      this.fragment.name + '()',
+    ])
+    const output = this.fragment.outputs?.[0]
+    const resultType = output?.type
+    assert(resultType, 'Expected output type')
+    const decoded = utils.defaultAbiCoder.decode(
+      [resultType],
+      response.data.toString(),
+    )
+    const value = decoded[0] as string
+    return { field: this.field, value: toContractValue(value) }
   }
 }

--- a/packages/discovery/src/discovery/handlers/system/SimpleMethodHandler.ts
+++ b/packages/discovery/src/discovery/handlers/system/SimpleMethodHandler.ts
@@ -79,6 +79,9 @@ export class SimpleMethodHandler implements MulticallableHandler {
       response.data.toString(),
     )
     const value = decoded[0] as string
-    return { field: this.field, value: toContractValue(value) }
+    return {
+      field: this.field,
+      value: toContractValue(value),
+    }
   }
 }

--- a/packages/discovery/src/discovery/handlers/user/AccessControlHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/AccessControlHandler.ts
@@ -4,7 +4,7 @@ import * as z from 'zod'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 
 export type AccessControlHandlerDefinition = z.infer<
   typeof AccessControlHandlerDefinition
@@ -23,7 +23,7 @@ const abi = new utils.Interface([
   'event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)',
 ])
 
-export class AccessControlHandler implements Handler {
+export class AccessControlHandler implements ClassicHandler {
   readonly dependencies: string[] = []
   private readonly knownNames = new Map<string, string>()
 

--- a/packages/discovery/src/discovery/handlers/user/ArrayFromOneEventHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/ArrayFromOneEventHandler.ts
@@ -5,7 +5,7 @@ import * as z from 'zod'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 import { getEventFragment } from '../utils/getEventFragment'
 import { toContractValue } from '../utils/toContractValue'
 
@@ -27,7 +27,7 @@ export const ArrayFromOneEventHandlerDefinition = z.strictObject({
   ignoreRelative: z.optional(z.boolean()),
 })
 
-export class ArrayFromOneEventHandler implements Handler {
+export class ArrayFromOneEventHandler implements ClassicHandler {
   readonly dependencies: string[] = []
   private readonly fragment: utils.EventFragment
   private readonly abi: utils.Interface

--- a/packages/discovery/src/discovery/handlers/user/ArrayFromOneEventWithArgHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/ArrayFromOneEventWithArgHandler.ts
@@ -5,7 +5,7 @@ import * as z from 'zod'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 import { getEventFragment } from '../utils/getEventFragment'
 import { toContractValue } from '../utils/toContractValue'
 
@@ -24,7 +24,7 @@ export const ArrayFromOneEventWithArgHandlerDefinition = z.strictObject({
   argValue: z.string(),
 })
 
-export class ArrayFromOneEventWithArgHandler implements Handler {
+export class ArrayFromOneEventWithArgHandler implements ClassicHandler {
   readonly dependencies: string[] = []
   private readonly fragment: utils.EventFragment
   private readonly abi: utils.Interface

--- a/packages/discovery/src/discovery/handlers/user/ArrayFromTwoEventsHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/ArrayFromTwoEventsHandler.ts
@@ -5,7 +5,7 @@ import * as z from 'zod'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 import { getEventFragment } from '../utils/getEventFragment'
 import { toContractValue } from '../utils/toContractValue'
 
@@ -21,7 +21,7 @@ export const ArrayFromTwoEventsHandlerDefinition = z.strictObject({
   ignoreRelative: z.optional(z.boolean()),
 })
 
-export class ArrayFromTwoEventsHandler implements Handler {
+export class ArrayFromTwoEventsHandler implements ClassicHandler {
   readonly dependencies: string[] = []
   private readonly addFragment: utils.EventFragment
   private readonly removeFragment: utils.EventFragment

--- a/packages/discovery/src/discovery/handlers/user/ArrayHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/ArrayHandler.ts
@@ -5,7 +5,7 @@ import * as z from 'zod'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 import { getReferencedName, Reference, resolveReference } from '../reference'
 import { callMethod } from '../utils/callMethod'
 import { getFunctionFragment } from '../utils/getFunctionFragment'
@@ -23,7 +23,7 @@ export const ArrayHandlerDefinition = z.strictObject({
 
 const DEFAULT_MAX_LENGTH = 100
 
-export class ArrayHandler implements Handler {
+export class ArrayHandler implements ClassicHandler {
   readonly dependencies: string[] = []
   readonly fragment: utils.FunctionFragment
 

--- a/packages/discovery/src/discovery/handlers/user/CallHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/CallHandler.ts
@@ -5,7 +5,7 @@ import * as z from 'zod'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 import { getReferencedName, resolveReference } from '../reference'
 import { callMethod, EXEC_REVERT_MSG } from '../utils/callMethod'
 import { getFunctionFragment } from '../utils/getFunctionFragment'
@@ -19,7 +19,7 @@ export const CallHandlerDefinition = z.strictObject({
   expectRevert: z.optional(z.boolean()),
 })
 
-export class CallHandler implements Handler {
+export class CallHandler implements ClassicHandler {
   readonly dependencies: string[] = []
   readonly fragment: utils.FunctionFragment
 

--- a/packages/discovery/src/discovery/handlers/user/ConstructorArgsHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/ConstructorArgsHandler.ts
@@ -6,7 +6,7 @@ import { z } from 'zod'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 
 export type ConstructorArgsDefinition = z.infer<
   typeof ConstructorArgsDefinition
@@ -16,7 +16,7 @@ export const ConstructorArgsDefinition = z.strictObject({
   nameArgs: z.boolean().optional(),
 })
 
-export class ConstructorArgsHandler implements Handler {
+export class ConstructorArgsHandler implements ClassicHandler {
   readonly dependencies: string[] = []
   readonly constructorFragment: ethers.utils.Fragment
 

--- a/packages/discovery/src/discovery/handlers/user/DynamicArrayHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/DynamicArrayHandler.ts
@@ -7,7 +7,7 @@ import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { getErrorMessage } from '../../../utils/getErrorMessage'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 import { getReferencedName, resolveReference } from '../reference'
 import { SingleSlot } from '../storageCommon'
 import { bytes32ToContractValue } from '../utils/bytes32ToContractValue'
@@ -30,7 +30,7 @@ export const DynamicArrayHandlerDefinition = z.strictObject({
   ignoreRelative: z.optional(z.boolean()),
 })
 
-export class DynamicArrayHandler implements Handler {
+export class DynamicArrayHandler implements ClassicHandler {
   readonly dependencies: string[]
 
   constructor(

--- a/packages/discovery/src/discovery/handlers/user/EventCountHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/EventCountHandler.ts
@@ -3,7 +3,7 @@ import * as z from 'zod'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 
 export type EventCountHandlerDefinition = z.infer<
   typeof EventCountHandlerDefinition
@@ -13,7 +13,7 @@ export const EventCountHandlerDefinition = z.strictObject({
   topics: z.array(z.string()),
 })
 
-export class EventCountHandler implements Handler {
+export class EventCountHandler implements ClassicHandler {
   readonly dependencies: string[] = []
 
   constructor(

--- a/packages/discovery/src/discovery/handlers/user/HardcodedHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/HardcodedHandler.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 import { DiscoveryLogger } from '../../DiscoveryLogger'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 
 export type HardCodedDefinition = z.infer<typeof HardCodedDefinition>
 export const HardCodedDefinition = z.strictObject({
@@ -9,7 +9,7 @@ export const HardCodedDefinition = z.strictObject({
   value: z.any(),
 })
 
-export class HardCodedHandler implements Handler {
+export class HardCodedHandler implements ClassicHandler {
   readonly dependencies: string[] = []
 
   constructor(

--- a/packages/discovery/src/discovery/handlers/user/LayerZeroMultisigHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/LayerZeroMultisigHandler.ts
@@ -6,7 +6,7 @@ import { z } from 'zod'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 import { toContractValue } from '../utils/toContractValue'
 import { toEventFragment } from '../utils/toEventFragment'
 import { ConstructorArgsHandler } from './ConstructorArgsHandler'
@@ -36,7 +36,7 @@ const ABI = new utils.Interface([
   UPDATE_QUORUM_EVENT_FRAGMENT,
 ])
 
-export class LayerZeroMultisigHandler implements Handler {
+export class LayerZeroMultisigHandler implements ClassicHandler {
   readonly dependencies: string[] = []
   readonly constructorArgsHandler: ConstructorArgsHandler
 

--- a/packages/discovery/src/discovery/handlers/user/ScrollAccessControlHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/ScrollAccessControlHandler.ts
@@ -6,7 +6,7 @@ import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
 import { ProxyDetector } from '../../proxies/ProxyDetector'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 
 export type ScrollAccessControlHandlerDefinition = z.infer<
   typeof ScrollAccessControlHandlerDefinition
@@ -27,7 +27,7 @@ const abi = new utils.Interface([
   'event RevokeAccess(bytes32 indexed role, address indexed target, bytes4[] selectors)',
 ])
 
-export class ScrollAccessControlHandler implements Handler {
+export class ScrollAccessControlHandler implements ClassicHandler {
   readonly dependencies: string[] = []
   private readonly knownNames = new Map<string, string>()
 

--- a/packages/discovery/src/discovery/handlers/user/StarkWareGovernanceHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/StarkWareGovernanceHandler.ts
@@ -5,7 +5,7 @@ import * as z from 'zod'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 import { callMethod } from '../utils/callMethod'
 import { getFunctionFragment } from '../utils/getFunctionFragment'
 import { toContractValue } from '../utils/toContractValue'
@@ -25,7 +25,7 @@ const EVENT_FRAGMENT = toEventFragment(
 const EVENT_KEY = 'acceptedGovernor'
 const ABI = new utils.Interface([EVENT_FRAGMENT])
 
-export class StarkWareGovernanceHandler implements Handler {
+export class StarkWareGovernanceHandler implements ClassicHandler {
   readonly dependencies: string[] = []
   readonly filterBy: utils.FunctionFragment
 

--- a/packages/discovery/src/discovery/handlers/user/StarkWareNamedStorageHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/StarkWareNamedStorageHandler.ts
@@ -6,7 +6,7 @@ import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { getErrorMessage } from '../../../utils/getErrorMessage'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 import { bytes32ToContractValue } from '../utils/bytes32ToContractValue'
 
 export type StarkWareNamedStorageHandlerDefinition = z.infer<
@@ -19,7 +19,7 @@ export const StarkWareNamedStorageHandlerDefinition = z.strictObject({
   ignoreRelative: z.optional(z.boolean()),
 })
 
-export class StarkWareNamedStorageHandler implements Handler {
+export class StarkWareNamedStorageHandler implements ClassicHandler {
   readonly dependencies = []
 
   constructor(

--- a/packages/discovery/src/discovery/handlers/user/StateFromEventHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/StateFromEventHandler.ts
@@ -7,7 +7,7 @@ import * as z from 'zod'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 import { getEventFragment } from '../utils/getEventFragment'
 import { toContractValue } from '../utils/toContractValue'
 
@@ -22,7 +22,7 @@ export const StateFromEventDefinition = z.strictObject({
   ignoreRelative: z.optional(z.boolean()),
 })
 
-export class StateFromEventHandler implements Handler {
+export class StateFromEventHandler implements ClassicHandler {
   readonly dependencies: string[] = []
   private readonly fragment: utils.EventFragment
   private readonly abi: utils.Interface

--- a/packages/discovery/src/discovery/handlers/user/StorageHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/StorageHandler.ts
@@ -6,7 +6,7 @@ import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { getErrorMessage } from '../../../utils/getErrorMessage'
 import { DiscoveryLogger } from '../../DiscoveryLogger'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
-import { Handler, HandlerResult } from '../Handler'
+import { ClassicHandler, HandlerResult } from '../Handler'
 import { getReferencedName, Reference, resolveReference } from '../reference'
 import { SingleSlot } from '../storageCommon'
 import { NumberFromString } from '../types'
@@ -24,7 +24,7 @@ export const StorageHandlerDefinition = z.strictObject({
   ignoreRelative: z.optional(z.boolean()),
 })
 
-export class StorageHandler implements Handler {
+export class StorageHandler implements ClassicHandler {
   readonly dependencies: string[]
 
   constructor(

--- a/packages/discovery/src/discovery/provider/multicall/MulticallClient.test.ts
+++ b/packages/discovery/src/discovery/provider/multicall/MulticallClient.test.ts
@@ -1,0 +1,248 @@
+import { expect, mockObject } from 'earl'
+
+import { Bytes } from '../../../utils/Bytes'
+import { EthereumAddress } from '../../../utils/EthereumAddress'
+import { DiscoveryProvider } from '../DiscoveryProvider'
+import { MulticallClient } from './MulticallClient'
+import {
+  decodeMulticallV1,
+  decodeMulticallV2,
+  encodeMulticallV1,
+  encodeMulticallV2,
+  multicallInterface,
+} from './MulticallConfig'
+import { MulticallConfigEntry } from './types'
+
+describe(MulticallClient.name, () => {
+  const ADDRESS_A = EthereumAddress('0x' + 'a'.repeat(40))
+  const ADDRESS_B = EthereumAddress('0x' + 'b'.repeat(40))
+  const ADDRESS_C = EthereumAddress('0x' + 'c'.repeat(40))
+
+  const ADDRESS_V2 = EthereumAddress('0x' + '2'.repeat(40))
+  const ADDRESS_V1 = EthereumAddress('0x' + '1'.repeat(40))
+
+  const MULTICALL_V2_BLOCK = 2_222
+  const MULTICALL_V1_BLOCK = 1_111
+  const BATCH_SIZE = 3
+  const TEST_MULTICALL_CONFIG: MulticallConfigEntry[] = [
+    {
+      sinceBlock: MULTICALL_V2_BLOCK,
+      batchSize: BATCH_SIZE,
+      address: ADDRESS_V2,
+      encodeBatch: encodeMulticallV2,
+      decodeBatch: decodeMulticallV2,
+    },
+    {
+      sinceBlock: MULTICALL_V1_BLOCK,
+      batchSize: BATCH_SIZE,
+      address: ADDRESS_V1,
+      encodeBatch: encodeMulticallV1,
+      decodeBatch: decodeMulticallV1,
+    },
+  ]
+
+  interface Call {
+    address?: EthereumAddress
+    data?: Bytes
+    blockNumber: number
+  }
+
+  it('falls back to individual requests for old block numbers', async () => {
+    const calls: Call[] = []
+    const DiscoveryProvider = mockObject<DiscoveryProvider>({
+      async call(address, data, blockNumber) {
+        calls.push({ address, data, blockNumber })
+        return data
+      },
+    })
+
+    const multicallClient = new MulticallClient(
+      DiscoveryProvider,
+      TEST_MULTICALL_CONFIG,
+    )
+    const blockNumber = MULTICALL_V1_BLOCK - 1
+    const result = await multicallClient.multicall(
+      [
+        { address: ADDRESS_A, data: Bytes.fromHex('0x123456') },
+        { address: ADDRESS_B, data: Bytes.fromHex('0x') },
+        { address: ADDRESS_C, data: Bytes.fromHex('0xdeadbeef') },
+      ],
+      blockNumber,
+    )
+    expect(result).toEqual([
+      { success: true, data: Bytes.fromHex('0x123456') },
+      // empty result is is treated as unsuccessful!
+      { success: false, data: Bytes.fromHex('0x') },
+      { success: true, data: Bytes.fromHex('0xdeadbeef') },
+    ])
+    expect(calls).toEqual([
+      { address: ADDRESS_A, data: Bytes.fromHex('0x123456'), blockNumber },
+      { address: ADDRESS_B, data: Bytes.fromHex('0x'), blockNumber },
+      { address: ADDRESS_C, data: Bytes.fromHex('0xdeadbeef'), blockNumber },
+    ])
+  })
+
+  it('uses v1 for blocks without v2', async () => {
+    const calls: Call[] = []
+    const discoveryProvider = mockObject<DiscoveryProvider>({
+      async call(address, data, blockNumber) {
+        calls.push({ address, data, blockNumber })
+        return Bytes.fromHex(
+          multicallInterface.encodeFunctionResult('aggregate', [
+            blockNumber.toString(),
+            ['0x12', '0x0f00', '0x'],
+          ]),
+        )
+      },
+    })
+
+    const multicallClient = new MulticallClient(
+      discoveryProvider,
+      TEST_MULTICALL_CONFIG,
+    )
+    const blockNumber = MULTICALL_V1_BLOCK + 1
+
+    const result = await multicallClient.multicall(
+      [
+        { address: ADDRESS_A, data: Bytes.fromHex('0x123456') },
+        { address: ADDRESS_B, data: Bytes.fromHex('0x') },
+        { address: ADDRESS_C, data: Bytes.fromHex('0xdeadbeef') },
+      ],
+      blockNumber,
+    )
+    expect(result).toEqual([
+      { success: true, data: Bytes.fromHex('0x12') },
+      { success: true, data: Bytes.fromHex('0x0f00') },
+      // empty result is is treated as unsuccessful!
+      { success: false, data: Bytes.fromHex('0x') },
+    ])
+    expect(calls).toEqual([
+      {
+        address: ADDRESS_V1,
+        data: encodeMulticallV1([
+          { address: ADDRESS_A, data: Bytes.fromHex('0x123456') },
+          { address: ADDRESS_B, data: Bytes.fromHex('0x') },
+          { address: ADDRESS_C, data: Bytes.fromHex('0xdeadbeef') },
+        ]),
+        blockNumber,
+      },
+    ])
+  })
+
+  it('uses v2 for new blocks', async () => {
+    const calls: Call[] = []
+    const discoveryProvider = mockObject<DiscoveryProvider>({
+      async call(address, data, blockNumber) {
+        calls.push({ address, data, blockNumber })
+        return Bytes.fromHex(
+          multicallInterface.encodeFunctionResult('tryAggregate', [
+            [
+              [true, '0x12'],
+              [false, '0x0f00'],
+              [true, '0x'],
+            ],
+          ]),
+        )
+      },
+    })
+
+    const multicallClient = new MulticallClient(
+      discoveryProvider,
+      TEST_MULTICALL_CONFIG,
+    )
+    const blockNumber = MULTICALL_V2_BLOCK + 1
+
+    const result = await multicallClient.multicall(
+      [
+        { address: ADDRESS_A, data: Bytes.fromHex('0x123456') },
+        { address: ADDRESS_B, data: Bytes.fromHex('0x') },
+        { address: ADDRESS_C, data: Bytes.fromHex('0xdeadbeef') },
+      ],
+      blockNumber,
+    )
+    expect(result).toEqual([
+      { success: true, data: Bytes.fromHex('0x12') },
+      { success: false, data: Bytes.fromHex('0x0f00') },
+      { success: false, data: Bytes.fromHex('0x') },
+    ])
+    expect(calls).toEqual([
+      {
+        address: ADDRESS_V2,
+        data: encodeMulticallV2([
+          { address: ADDRESS_A, data: Bytes.fromHex('0x123456') },
+          { address: ADDRESS_B, data: Bytes.fromHex('0x') },
+          { address: ADDRESS_C, data: Bytes.fromHex('0xdeadbeef') },
+        ]),
+        blockNumber,
+      },
+    ])
+  })
+
+  it(`batches calls`, async () => {
+    const calls: number[] = []
+    const discoveryProvider = mockObject<DiscoveryProvider>({
+      async call(_, data) {
+        const callCount: number = multicallInterface.decodeFunctionData(
+          'tryAggregate',
+          data.toString(),
+        )[1].length
+        calls.push(callCount)
+        return Bytes.fromHex(
+          multicallInterface.encodeFunctionResult('tryAggregate', [
+            new Array(callCount).fill(0).map(() => [true, '0x1234']),
+          ]),
+        )
+      },
+    })
+
+    const multicallClient = new MulticallClient(
+      discoveryProvider,
+      TEST_MULTICALL_CONFIG,
+    )
+    const blockNumber = MULTICALL_V2_BLOCK + 1
+
+    const result = await multicallClient.multicall(
+      new Array(BATCH_SIZE * 2 + 1).fill(0).map(() => ({
+        address: ADDRESS_A,
+        data: Bytes.fromHex('0x123456'),
+      })),
+      blockNumber,
+    )
+    expect(result.length).toEqual(BATCH_SIZE * 2 + 1)
+    expect(calls).toEqual([BATCH_SIZE, BATCH_SIZE, 1])
+  })
+
+  it('offers a named interface', async () => {
+    const discoveryProvider = mockObject<DiscoveryProvider>({
+      async call() {
+        return Bytes.fromHex(
+          multicallInterface.encodeFunctionResult('tryAggregate', [
+            [
+              [true, '0x1234'],
+              [false, '0xdead'],
+            ],
+          ]),
+        )
+      },
+    })
+
+    const multicallClient = new MulticallClient(
+      discoveryProvider,
+      TEST_MULTICALL_CONFIG,
+    )
+    const blockNumber = MULTICALL_V2_BLOCK + 1
+
+    const result = await multicallClient.multicallNamed(
+      {
+        foo: [{ address: ADDRESS_A, data: Bytes.fromHex('0x123456') }],
+        bar: [{ address: ADDRESS_B, data: Bytes.fromHex('0x') }],
+      },
+      blockNumber,
+    )
+
+    expect(result).toEqual({
+      foo: [{ success: true, data: Bytes.fromHex('0x1234') }],
+      bar: [{ success: false, data: Bytes.fromHex('0xdead') }],
+    })
+  })
+})

--- a/packages/discovery/src/discovery/provider/multicall/MulticallClient.ts
+++ b/packages/discovery/src/discovery/provider/multicall/MulticallClient.ts
@@ -1,0 +1,101 @@
+import { DiscoveryProvider } from '../DiscoveryProvider'
+import {
+  MulticallConfig,
+  MulticallConfigEntry,
+  MulticallRequest,
+  MulticallResponse,
+} from './types'
+
+export class MulticallClient {
+  constructor(
+    private readonly provider: DiscoveryProvider,
+    private readonly config: MulticallConfig,
+  ) {}
+
+  async multicallNamed(
+    requests: Record<string, MulticallRequest[]>,
+    blockNumber: number,
+  ): Promise<Record<string, MulticallResponse[]>> {
+    const entries = Object.entries(requests)
+    const calls = entries.map((x) => x[1]).flat()
+    const results = await this.multicall(calls, blockNumber)
+    const responses = new Map<string, MulticallResponse[]>()
+    for (const entry of entries) {
+      for (const _ of entry[1]) {
+        const result = results.shift()
+        if (!result) {
+          throw new Error('Unexpected result')
+        }
+        const response = responses.get(entry[0])
+        if (response) {
+          response.push(result)
+        } else {
+          responses.set(entry[0], [result])
+        }
+      }
+    }
+
+    return Object.fromEntries(responses)
+  }
+
+  async multicall(
+    requests: MulticallRequest[],
+    blockNumber: number,
+  ): Promise<MulticallResponse[]> {
+    const config = this.config.find((x) => blockNumber >= x.sinceBlock)
+    try {
+      if (!config) {
+        return this.executeIndividual(requests, blockNumber)
+      } else {
+        const batches = toBatches(requests, config.batchSize)
+        const batchedResults = await Promise.all(
+          batches.map((batch) => this.executeBatch(config, batch, blockNumber)),
+        )
+        return batchedResults.flat()
+      }
+    } catch (e) {
+      throw new Error(
+        `Ethereum multicall failed for block number:  ${blockNumber}. Call size was ${requests.length}.`,
+      )
+    }
+  }
+
+  private async executeIndividual(
+    requests: MulticallRequest[],
+    blockNumber: number,
+  ): Promise<MulticallResponse[]> {
+    const results = await Promise.all(
+      requests.map((request) =>
+        this.provider.call(request.address, request.data, blockNumber),
+      ),
+    )
+    return results.map(
+      (result): MulticallResponse => ({
+        success: result.length !== 0,
+        data: result,
+      }),
+    )
+  }
+
+  private async executeBatch(
+    config: MulticallConfigEntry,
+    requests: MulticallRequest[],
+    blockNumber: number,
+  ): Promise<MulticallResponse[]> {
+    const encoded = config.encodeBatch(requests)
+    const result = await this.provider.call(
+      config.address,
+      encoded,
+      blockNumber,
+    )
+    return config.decodeBatch(result)
+  }
+}
+
+export function toBatches<T>(items: T[], batchSize: number): T[][] {
+  const batches: T[][] = []
+  for (let i = 0; i < items.length; i += batchSize) {
+    batches.push(items.slice(i, i + batchSize))
+  }
+  return batches
+}

--- a/packages/discovery/src/discovery/provider/multicall/MulticallConfig.ts
+++ b/packages/discovery/src/discovery/provider/multicall/MulticallConfig.ts
@@ -1,0 +1,140 @@
+import { utils } from 'ethers'
+
+import { Bytes } from '../../../utils/Bytes'
+import { EthereumAddress } from '../../../utils/EthereumAddress'
+import { MulticallConfig, MulticallRequest, MulticallResponse } from './types'
+
+export const ETHEREUM_MULTICALL_V1_ADDRESS = EthereumAddress(
+  '0xeefBa1e63905eF1D7ACbA5a8513c70307C1cE441',
+)
+export const ETHEREUM_MULTICALL_V1_BLOCK = 7929876
+
+export const ETHEREUM_MULTICALL_CONFIG: MulticallConfig = [
+  {
+    sinceBlock: 12336033,
+    batchSize: 150,
+    address: EthereumAddress('0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696'),
+    encodeBatch: encodeMulticallV2,
+    decodeBatch: decodeMulticallV2,
+  },
+  {
+    sinceBlock: ETHEREUM_MULTICALL_V1_BLOCK,
+    batchSize: 150,
+    address: ETHEREUM_MULTICALL_V1_ADDRESS,
+    encodeBatch: encodeMulticallV1,
+    decodeBatch: decodeMulticallV1,
+  },
+]
+
+export const ARBITRUM_MULTICALL_CONFIG: MulticallConfig = [
+  {
+    sinceBlock: 821923,
+    batchSize: 150,
+    address: EthereumAddress('0x842eC2c7D803033Edf55E478F461FC547Bc54EB2'),
+    encodeBatch: encodeMulticallV2,
+    decodeBatch: decodeMulticallV2,
+  },
+]
+
+export const OPTIMISM_MULTICALL_CONFIG: MulticallConfig = [
+  {
+    sinceBlock: 0,
+    batchSize: 150,
+    address: EthereumAddress('0xE295aD71242373C37C5FdA7B57F26f9eA1088AFe'),
+    encodeBatch: encodeOptimismMulticall,
+    decodeBatch: decodeOptimismMulticall,
+  },
+]
+
+export const BASE_MULTICALL_CONFIG: MulticallConfig = [
+  {
+    sinceBlock: 5022,
+    batchSize: 150,
+    address: EthereumAddress('0xcA11bde05977b3631167028862bE2a173976CA11'),
+    encodeBatch: encodeMulticallV2,
+    decodeBatch: decodeMulticallV2,
+  },
+]
+
+export const multicallInterface = new utils.Interface([
+  'function multicall(tuple(address, bytes)[] memory calls) public returns (bytes[] memory results)',
+  'function aggregate(tuple(address target, bytes callData)[] calls) public returns (uint256 blockNumber, bytes[] returnData)',
+  'function tryAggregate(bool requireSuccess, tuple(address target, bytes callData)[] calls) public returns (tuple(bool success, bytes returnData)[] returnData)',
+])
+
+export function encodeMulticallV1(requests: MulticallRequest[]): Bytes {
+  const string = multicallInterface.encodeFunctionData('aggregate', [
+    requests.map((request): [string, string] => [
+      request.address.toString(),
+      request.data.toString(),
+    ]),
+  ])
+  return Bytes.fromHex(string)
+}
+
+export function decodeMulticallV1(result: Bytes): MulticallResponse[] {
+  const decoded = multicallInterface.decodeFunctionResult(
+    'aggregate',
+    result.toString(),
+  )
+  const values = decoded[1] as string[]
+  return values.map(
+    (data): MulticallResponse => ({
+      success: data !== '0x',
+      data: Bytes.fromHex(data),
+    }),
+  )
+}
+
+export function encodeMulticallV2(requests: MulticallRequest[]): Bytes {
+  const string = multicallInterface.encodeFunctionData('tryAggregate', [
+    false,
+    requests.map((request): [string, string] => [
+      request.address.toString(),
+      request.data.toString(),
+    ]),
+  ])
+  return Bytes.fromHex(string)
+}
+
+export function decodeMulticallV2(result: Bytes): MulticallResponse[] {
+  const decoded = multicallInterface.decodeFunctionResult(
+    'tryAggregate',
+    result.toString(),
+  )
+  const values = decoded[0] as [boolean, string][]
+  return values.map(([success, data]): MulticallResponse => {
+    const bytes = Bytes.fromHex(data)
+    return {
+      success: success && bytes.length !== 0,
+      data: bytes,
+    }
+  })
+}
+
+export function encodeOptimismMulticall(requests: MulticallRequest[]): Bytes {
+  const hexCalldata = multicallInterface.encodeFunctionData('multicall', [
+    requests.map((request) => [
+      request.address.toString(),
+      request.data.toString(),
+    ]),
+  ])
+
+  return Bytes.fromHex(hexCalldata)
+}
+
+export function decodeOptimismMulticall(response: Bytes): MulticallResponse[] {
+  const decodedResponse = multicallInterface.decodeFunctionResult(
+    'multicall',
+    response.toString(),
+  )
+
+  const values = decodedResponse[0] as string[]
+
+  return values.map(
+    (data): MulticallResponse => ({
+      success: data !== '0x',
+      data: Bytes.fromHex(data),
+    }),
+  )
+}

--- a/packages/discovery/src/discovery/provider/multicall/types.ts
+++ b/packages/discovery/src/discovery/provider/multicall/types.ts
@@ -1,8 +1,7 @@
 import { Bytes } from '../../../utils/Bytes'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 
-export type MulticallConfig = MulticallConfigEntry[]
-export interface MulticallConfigEntry {
+export interface MulticallConfig {
   sinceBlock: number
   batchSize: number
   address: EthereumAddress

--- a/packages/discovery/src/discovery/provider/multicall/types.ts
+++ b/packages/discovery/src/discovery/provider/multicall/types.ts
@@ -1,0 +1,21 @@
+import { Bytes } from '../../../utils/Bytes'
+import { EthereumAddress } from '../../../utils/EthereumAddress'
+
+export type MulticallConfig = MulticallConfigEntry[]
+export interface MulticallConfigEntry {
+  sinceBlock: number
+  batchSize: number
+  address: EthereumAddress
+  encodeBatch: (requests: MulticallRequest[]) => Bytes
+  decodeBatch: (result: Bytes) => MulticallResponse[]
+}
+
+export interface MulticallRequest {
+  address: EthereumAddress
+  data: Bytes
+}
+
+export interface MulticallResponse {
+  success: boolean
+  data: Bytes
+}

--- a/packages/discovery/src/index.ts
+++ b/packages/discovery/src/index.ts
@@ -14,6 +14,7 @@ export {
 } from './discovery/output/diffDiscovery'
 export { toDiscoveryOutput } from './discovery/output/toDiscoveryOutput'
 export { DiscoveryProvider } from './discovery/provider/DiscoveryProvider'
+export { MulticallClient } from './discovery/provider/multicall/MulticallClient'
 export type { DiscoveryCache } from './discovery/provider/ProviderWithCache'
 export { ProviderWithCache } from './discovery/provider/ProviderWithCache'
 export { RateLimitedProvider } from './discovery/provider/RateLimitedProvider'

--- a/packages/discovery/src/index.ts
+++ b/packages/discovery/src/index.ts
@@ -15,6 +15,7 @@ export {
 export { toDiscoveryOutput } from './discovery/output/toDiscoveryOutput'
 export { DiscoveryProvider } from './discovery/provider/DiscoveryProvider'
 export { MulticallClient } from './discovery/provider/multicall/MulticallClient'
+export { multicallConfig } from './discovery/provider/multicall/MulticallConfig'
 export type { DiscoveryCache } from './discovery/provider/ProviderWithCache'
 export { ProviderWithCache } from './discovery/provider/ProviderWithCache'
 export { RateLimitedProvider } from './discovery/provider/RateLimitedProvider'

--- a/packages/discovery/src/singleDiscovery.ts
+++ b/packages/discovery/src/singleDiscovery.ts
@@ -46,6 +46,7 @@ export async function singleDiscovery(
   const results = await discovery(
     provider,
     etherscanClient,
+    chainConfig.multicall,
     projectConfig,
     DiscoveryLogger.CLI,
     blockNumber,


### PR DESCRIPTION
Resolves L2B-2439

### Context

This PR introduces a performance improvement on the discovery, especially during watch mode by calling all `SimpleMethodHandler` in one call using multicall.

I decided to only implement `SimpleMethodHandler` as `MulticallableHandler` for 2 main reasons: 
- this brings by far the most performance increase to `lz-monitoring` (4x fewer calls)
- `ArrayHandler` is really tricky, as we need to make sure that the handler gives us readable errors (or we don't?). 

Anyway, it will be easier to think about it once we have a working framework, which this PR introduces, so welcome to the discussion.

I'm keeping the `execute` function for now, maybe it's useful in the future.

All the multicall contract addresses are from viem repository. Most of them have been deployed over a year ago, which is enough for us.

