### PR TITLE
Add discovery cache to .gitignore

### DIFF
--- a/packages/discovery/.gitignore
+++ b/packages/discovery/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 .env
+cache


### PR DESCRIPTION
If you run discovery in the tools package the cache shows up in the `git status`. To make it go away I've added the cache path to the .gitignore file.