### PR TITLE
Allow for errors to be defined in the parameters

### DIFF
--- a/packages/backend-tools/CHANGELOG.md
+++ b/packages/backend-tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/backend-tools
 
+## 0.4.1
+
+### Patch Changes
+
+- Allow for error to be defined in the parameters object
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/backend-tools/package.json
+++ b/packages/backend-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/backend-tools",
   "description": "Common utilities for L2BEAT projects.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "repository": "https://github.com/l2beat/tools",
   "bugs": {

--- a/packages/backend-tools/package.json
+++ b/packages/backend-tools/package.json
@@ -32,10 +32,12 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "dotenv": "^16.3.1",
-    "error-stack-parser": "^2.1.4"
+    "error-stack-parser": "^2.1.4",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@sinonjs/fake-timers": "^11.1.0",
-    "@types/sinonjs__fake-timers": "^8.1.2"
+    "@types/sinonjs__fake-timers": "^8.1.2",
+    "@types/lodash": "^4.14.198"
   }
 }

--- a/packages/backend-tools/src/logger/Logger.test.ts
+++ b/packages/backend-tools/src/logger/Logger.test.ts
@@ -265,7 +265,7 @@ describe(Logger.name, () => {
       logger.error('foo', { error: new Error('bar'), x: 1, y: 2 })
       expect(mockReportError).toHaveBeenNthCalledWith(9, {
         message: 'foo',
-        parameters: {x: 1, y:2},
+        parameters: { x: 1, y: 2 },
         error: new Error('bar'),
       })
     })

--- a/packages/backend-tools/src/logger/Logger.test.ts
+++ b/packages/backend-tools/src/logger/Logger.test.ts
@@ -254,6 +254,20 @@ describe(Logger.name, () => {
         parameters: { x: 1, y: 2, message: true },
         error: undefined,
       })
+
+      logger.error('foo', { error: new Error('bar') })
+      expect(mockReportError).toHaveBeenNthCalledWith(8, {
+        message: 'foo',
+        parameters: undefined,
+        error: new Error('bar'),
+      })
+
+      logger.error('foo', { error: new Error('bar'), x: 1, y: 2 })
+      expect(mockReportError).toHaveBeenNthCalledWith(9, {
+        message: 'foo',
+        parameters: {x: 1, y:2},
+        error: new Error('bar'),
+      })
     })
   })
 })

--- a/packages/backend-tools/src/logger/Logger.ts
+++ b/packages/backend-tools/src/logger/Logger.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { join } from 'path'
+import { isEmpty } from 'lodash'
 
 import { assertUnreachable } from '../utils/assertUnreachable'
 import { formatLevelPretty } from './formatLevelPretty'
@@ -281,7 +282,16 @@ function toReportedError(arg1: unknown, arg2: unknown): ReportedError {
     if (arg2 instanceof Error) {
       error = arg2
     } else if (arg2 !== undefined) {
-      parameters = arg2
+      if (typeof arg2 === 'object' && arg2 !== null) {
+        const shallow = { ...arg2 } as Record<string, unknown>
+        const errorLike: unknown = Reflect.get(arg2, 'error')
+        if (errorLike instanceof Error) {
+          error = errorLike
+          delete shallow.error
+        }
+
+        parameters = isEmpty(shallow) ? undefined : shallow
+      }
     }
   } else {
     if (arg1 instanceof Error) {

--- a/packages/backend-tools/src/logger/Logger.ts
+++ b/packages/backend-tools/src/logger/Logger.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import { join } from 'path'
 import { isEmpty } from 'lodash'
+import { join } from 'path'
 
 import { assertUnreachable } from '../utils/assertUnreachable'
 import { formatLevelPretty } from './formatLevelPretty'


### PR DESCRIPTION
Resovles L2B-2855

The TaskQueue does the following while reporting a halting error
```
this.logger.error('Halting queue because of error', {
  job: JSON.stringify(job),
  error,
})
```

Logger did not extract the error from the second argument when it was an object when generating the `ReportedError` object that is later sent to sentry. In turn in sentry we only saw the `Halting queue because of error`, because the error was not found in the second argument parameters object. This PR allows for sending an error as part of the parameters object.