### PR TITLE
Require block number when working with cache (getTransaction)

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.19.0
+
+### Minor Changes
+
+- Block number is now required when working with cache despite invoked method
+
 ## 0.18.4
 
 ### Patch Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.18.4",
+  "version": "0.19.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/discovery/provider/ProviderWithCache.test.ts
+++ b/packages/discovery/src/discovery/provider/ProviderWithCache.test.ts
@@ -240,6 +240,7 @@ describe(ProviderWithCache.name, () => {
           reorgSafeDepth: 1000, // Doesn't matter
         })
 
+      // Force cache-miss to trigger getTransaction
       mockCache.get = mockFn().resolvesToOnce(undefined)
       mockProvider.getTransaction = mockFn().resolvesTo(nonMinedTransactions)
 

--- a/packages/discovery/src/discovery/provider/ProviderWithCache.test.ts
+++ b/packages/discovery/src/discovery/provider/ProviderWithCache.test.ts
@@ -3,6 +3,7 @@ import { providers } from 'ethers'
 
 import { ChainId } from '../../utils/ChainId'
 import { EtherscanLikeClient } from '../../utils/EtherscanLikeClient'
+import { Hash256 } from '../../utils/Hash256'
 import { DiscoveryLogger } from '../DiscoveryLogger'
 import { DiscoveryCache, ProviderWithCache } from './ProviderWithCache'
 
@@ -35,26 +36,6 @@ function setupProviderWithMockCache(values: {
 
 describe(ProviderWithCache.name, () => {
   describe(ProviderWithCache.prototype.cacheOrFetch.name, () => {
-    it('works when reorgSafeDepth and blockNumber is undefined, value cached', async () => {
-      const { providerWithCache, mockCache } = setupProviderWithMockCache({
-        curBlockNumber: 1000,
-        reorgSafeDepth: undefined,
-      })
-
-      const blockNumber = undefined
-      const result = await providerWithCache.cacheOrFetch(
-        'mockCachedKey',
-        blockNumber,
-        async () => 'mockNotCachedValue',
-        (value) => value,
-        (value) => value,
-      )
-
-      expect(result).toEqual('mockCachedValue')
-      expect(mockCache.get).toHaveBeenCalledWith('mockCachedKey')
-      expect(mockCache.set).toHaveBeenCalledTimes(0)
-    })
-
     it('works when reorgSafeDepth is undefined, value cached', async () => {
       const { providerWithCache, mockCache } = setupProviderWithMockCache({
         curBlockNumber: 1000,
@@ -73,30 +54,6 @@ describe(ProviderWithCache.name, () => {
       expect(result).toEqual('mockCachedValue')
       expect(mockCache.get).toHaveBeenCalledWith('mockCachedKey')
       expect(mockCache.set).toHaveBeenCalledTimes(0)
-    })
-
-    it('works when reorgSafeDepth and blockNumber is undefined, value not cached', async () => {
-      const { providerWithCache, mockCache } = setupProviderWithMockCache({
-        curBlockNumber: 1000,
-        reorgSafeDepth: undefined,
-      })
-
-      const blockNumber = undefined
-      const result = await providerWithCache.cacheOrFetch(
-        'mockNotCachedKey',
-        blockNumber,
-        async () => 'mockNotCachedValue',
-        (value) => value,
-        (value) => value,
-      )
-
-      expect(result).toEqual('mockNotCachedValue')
-      expect(mockCache.set).toHaveBeenCalledWith(
-        'mockNotCachedKey',
-        'mockNotCachedValue',
-        1,
-        blockNumber,
-      )
     })
 
     it('works when reorgSafeDepth is undefined, value not cached', async () => {
@@ -263,6 +220,35 @@ describe(ProviderWithCache.name, () => {
         curTimeMs + 120_000,
       )
       expect(mockProvider.getBlockNumber).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe(ProviderWithCache.prototype.getTransaction.name, () => {
+    it('throws and does not cache non-mined transactions', async () => {
+      const txHash = Hash256.random()
+
+      const nonMinedTransactions = {
+        transactionHash: txHash,
+        blockNumber: undefined,
+        blockHash: undefined,
+        timestamp: undefined,
+      }
+
+      const { providerWithCache, mockCache, mockProvider } =
+        setupProviderWithMockCache({
+          curBlockNumber: 1000, // Doesn't matter
+          reorgSafeDepth: 1000, // Doesn't matter
+        })
+
+      mockCache.get = mockFn().resolvesToOnce(undefined)
+      mockProvider.getTransaction = mockFn().resolvesTo(nonMinedTransactions)
+
+      await expect(() =>
+        providerWithCache.getTransaction(txHash),
+      ).toBeRejectedWith('Transaction not mined')
+
+      expect(mockCache.get).toHaveBeenCalledTimes(1)
+      expect(mockCache.set).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/discovery/src/discovery/provider/SQLiteCache.test.ts
+++ b/packages/discovery/src/discovery/provider/SQLiteCache.test.ts
@@ -64,27 +64,6 @@ describe('SQLiteCache', () => {
       expect(result.blockNumber).toEqual(newBlockNumber)
       expect(result.chainId).toEqual(newChainId)
     }))
-
-  it('transforms undefined into null', () =>
-    withTemporaryFile(async (sqlCache, rqe) => {
-      const key = 'key'
-      const value = 'value'
-      const chainId = 1
-      const blockNumber = undefined
-
-      await sqlCache.set(key, value, chainId, blockNumber)
-
-      const resultRaw = await rqe.query<CacheEntry[]>(
-        'SELECT * FROM cache WHERE key=$1',
-        [key],
-      )
-
-      const [result] = resultRaw
-
-      assert(result)
-
-      expect(result.blockNumber).toEqual(null!)
-    }))
 })
 
 interface CacheEntry {


### PR DESCRIPTION
Resolves L2B-2888

## What's changed

Up til now, `blockNumber` was optional when working with cache entries since `getTranasction` was unable to provide viable block number to reference to when invalidating cache.

## Important notices

**Important**: Explicit error will be thrown mid-way since we don't want to cache nor return transactions that have not yet been mined.

**Important V2**: Any existing cache must be **pruned** off `getTransaction` cache entries since those will have no time reference and cannot be invalidated, thus poisoning the cache.