### PR TITLE
Dont discover fnunctions with no output

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.21.0
+
+### Minor Changes
+
+- Skip functions with no outputs during discovery
+
 ## 0.20.0
 
 ### Minor Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/discovery/handlers/getHandlers.test.ts
+++ b/packages/discovery/src/discovery/handlers/getHandlers.test.ts
@@ -84,6 +84,18 @@ describe(getHandlers.name, () => {
     expect(handlers).toEqual([])
   })
 
+  it("ignores methods that don't return anything", () => {
+    const handlers = getHandlers(
+      [
+        'function requireUnresolved(uint256 nodeNum) view',
+        'function requireUnresolvedExists() view',
+      ],
+      undefined,
+      DiscoveryLogger.SILENT,
+    )
+    expect(handlers).toEqual([])
+  })
+
   it('ignores write methods', () => {
     const handlers = getHandlers(
       ['function write()'],

--- a/packages/discovery/src/discovery/handlers/getSystemHandlers.ts
+++ b/packages/discovery/src/discovery/handlers/getSystemHandlers.ts
@@ -17,8 +17,8 @@ export function getSystemHandlers(
   const arrayHandlers: Handler[] = []
 
   for (const fn of Object.values(abi.functions)) {
-    if (!fn.constant) {
-      // function is neither pure nor view
+    if (!fn.constant || (fn.outputs?.length ?? 0) === 0) {
+      // function is neither pure nor view, or simply doesn't return anything
       continue
     } else if (overrides?.ignoreMethods?.includes(fn.name)) {
       logger.log(`  Skipping ${fn.name}`)


### PR DESCRIPTION
If a abi function doesn't return anything, we should not call it. Currently it's shown as returning empty array, which is not right.