### PR TITLE
Cache getCode() with blockNumber

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.21.2
+
+### Patch Changes
+
+- Cache getCode() with blockNumber because the code can change
+
 ## 0.21.1
 
 ### Patch Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/discovery/provider/ProviderWithCache.ts
+++ b/packages/discovery/src/discovery/provider/ProviderWithCache.ts
@@ -206,11 +206,13 @@ export class ProviderWithCache extends DiscoveryProvider {
     address: EthereumAddress,
     blockNumber: number,
   ): Promise<Bytes> {
-    const key = this.buildKey(
-      'getCode',
-      // Ignoring blockNumber here, assuming that code will not change
-      [address],
-    )
+    // Contract code can change at any moment, so we cache *with blockNumber*
+    // see: https://medium.com/coinmonks/dark-side-of-create2-opcode-6b6838a42d71
+    // Another problem is running discovery on a very old block number
+    // when some contract has not been deployed yet:
+    // getCode() would return previously cached value instead of empty code.
+
+    const key = this.buildKey('getCode', [blockNumber, address])
 
     return this.cacheOrFetch(
       key,


### PR DESCRIPTION
Contract code can change at any moment, so we cache *with blockNumber*
see: https://medium.com/coinmonks/dark-side-of-create2-opcode-6b6838a42d71
Another problem is running discovery on a very old block number
when some contract has not been deployed yet:
getCode() would return previously cached value instead of empty code.