### PR TITLE
Fix dependency error when value is 0

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.21.3
+
+### Patch Changes
+
+- Fix dependency error when value is 0
+
 ## 0.21.2
 
 ### Patch Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/discovery/handlers/reference.ts
+++ b/packages/discovery/src/discovery/handlers/reference.ts
@@ -27,7 +27,7 @@ export function resolveReference<T extends string | unknown>(
   if (result.error) {
     throw new Error(`Dependency error: ${result.error}`)
   }
-  if (!result.value) {
+  if (result.value === undefined) {
     throw new Error(`Dependency error: missing value`)
   }
   return result.value


### PR DESCRIPTION
### Context

Only undefined values should throw a dependency error. 