### PR TITLE
Improve the Zodiac modules discovery implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "clean": "wsrun -recsm clean",
     "build": "wsrun -recsm build",
+    "build:dependencies": "wsrun -p @l2beat/{backend-tools,discovery-types} -recsm build",
     "test": "wsrun -ecam test",
     "format:fix": "wsrun -ecam format:fix",
     "format": "wsrun -ecam format",

--- a/packages/discovery-types/CHANGELOG.md
+++ b/packages/discovery-types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery-types
 
+## 0.7.0
+
+### Minor Changes
+
+- Improve Zodiac Module detection heuristic
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/discovery-types/package.json
+++ b/packages/discovery-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery-types",
   "description": "Common types for @l2beat/discovery.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "repository": "https://github.com/l2beat/tools",
   "bugs": {

--- a/packages/discovery-types/src/proxyDetails.ts
+++ b/packages/discovery-types/src/proxyDetails.ts
@@ -57,7 +57,7 @@ export interface GnosisSafeZodiacModuleUpgradeability {
   avatar: EthereumAddress
   target: EthereumAddress
   guard: EthereumAddress
-  modules: EthereumAddress[]
+  modules?: EthereumAddress[]
 }
 
 export interface EIP1967ProxyUpgradeability {

--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @l2beat/discovery
 
+## 0.27.0
+
+### Minor Changes
+
+- Improve Zodiac Module detection heuristic
+
+### Patch Changes
+
+- Updated dependencies
+  - @l2beat/discovery-types@0.7.0
+
 ## 0.26.0
 
 ### Minor Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "build:dependencies": "cd ../.. && yarn build:dependencies",
     "clean": "rm -rf dist",
     "format:fix": "prettier --write .",
     "format": "prettier --check .",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@l2beat/backend-tools": "^0.5.0",
-    "@l2beat/discovery-types": "^0.6.0",
+    "@l2beat/discovery-types": "^0.7.0",
     "chalk": "^4.1.2",
     "deep-diff": "^1.0.2",
     "dotenv": "^16.0.3",

--- a/packages/discovery/src/discovery/proxies/auto/GnosisSafe.ts
+++ b/packages/discovery/src/discovery/proxies/auto/GnosisSafe.ts
@@ -5,6 +5,7 @@ import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
 import { bytes32ToAddress } from '../../utils/address'
 import { getCallResult } from '../../utils/getCallResult'
+import { getModules } from '../../utils/getSafeModules'
 
 async function getMasterCopy(
   provider: DiscoveryProvider,
@@ -27,38 +28,6 @@ async function getMasterCopy(
   }
 }
 
-export async function getModules(
-  provider: DiscoveryProvider,
-  address: EthereumAddress,
-  blockNumber: number,
-): Promise<EthereumAddress[]> {
-  // Sentinel value used by Gnosis Safe to indicate the beginning and
-  // the end of the circular linked list.
-  // https://github.com/safe-global/safe-contracts/blob/52ce39c89cc3e3529963100dd774a6a03c098792/contracts/base/ModuleManager.sol#L23C35-L23C35
-  const SENTINEL_MODULES = '0x0000000000000000000000000000000000000001'
-  const PAGINATION_SIZE = 10
-
-  let next = SENTINEL_MODULES
-  const modules: EthereumAddress[] = []
-  do {
-    // Result: [modules[], next]
-    const result = await getCallResult<[string[], string]>(
-      provider,
-      address,
-      'function getModulesPaginated(address start, uint256 pageSize) view returns (address[] array, address next)',
-      [next, PAGINATION_SIZE],
-      blockNumber,
-      true,
-    )
-
-    assert(result, 'Failed to get modules')
-
-    result[0].forEach((module) => modules.push(EthereumAddress(module)))
-    next = result[1]
-  } while (next !== SENTINEL_MODULES)
-  return modules
-}
-
 export async function detectGnosisSafe(
   provider: DiscoveryProvider,
   address: EthereumAddress,
@@ -68,7 +37,9 @@ export async function detectGnosisSafe(
   if (!masterCopy) {
     return
   }
+
   const modules = await getModules(provider, address, blockNumber)
+  assert(modules, 'Could not find modules for GnosisSafe')
 
   return {
     implementations: [masterCopy],

--- a/packages/discovery/src/discovery/proxies/auto/GnosisSafeModule.ts
+++ b/packages/discovery/src/discovery/proxies/auto/GnosisSafeModule.ts
@@ -4,11 +4,9 @@ import { Bytes } from '../../../utils/Bytes'
 import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
 import { bytes32ToAddress } from '../../utils/address'
+import { getCallResult } from '../../utils/getCallResult'
 import { getModules } from './GnosisSafe'
 
-const GUARD_SLOT = Bytes.fromHex(
-  '0x0000000000000000000000000000000000000000000000000000000000000065',
-)
 const AVATAR_SLOT = Bytes.fromHex(
   '0x0000000000000000000000000000000000000000000000000000000000000066',
 )
@@ -40,9 +38,13 @@ async function getGuard(
   provider: DiscoveryProvider,
   address: EthereumAddress,
   blockNumber: number,
-): Promise<EthereumAddress> {
-  return bytes32ToAddress(
-    await provider.getStorage(address, GUARD_SLOT, blockNumber),
+): Promise<EthereumAddress | undefined> {
+  return await getCallResult<EthereumAddress>(
+    provider,
+    address,
+    'function getGuard() external view returns (address _guard)',
+    [],
+    blockNumber,
   )
 }
 
@@ -51,18 +53,20 @@ export async function detectGnosisSafeZodiacModule(
   address: EthereumAddress,
   blockNumber: number,
 ): Promise<ProxyDetails | undefined> {
-  const { avatar, target } = await getAvatarAndTarget(
-    provider,
-    address,
-    blockNumber,
-  )
-  if (avatar === EthereumAddress.ZERO || target === EthereumAddress.ZERO) {
+  const [guard, { avatar, target }] = await Promise.all([
+    getGuard(provider, address, blockNumber),
+    getAvatarAndTarget(provider, address, blockNumber),
+  ])
+
+  if (
+    guard === undefined ||
+    avatar === EthereumAddress.ZERO ||
+    target === EthereumAddress.ZERO
+  ) {
     return
   }
-  const [guard, modules] = await Promise.all([
-    getGuard(provider, address, blockNumber),
-    getModules(provider, address, blockNumber),
-  ])
+
+  const modules = await getModules(provider, address, blockNumber)
 
   return {
     implementations: [],

--- a/packages/discovery/src/discovery/proxies/auto/GnosisSafeModule.ts
+++ b/packages/discovery/src/discovery/proxies/auto/GnosisSafeModule.ts
@@ -5,7 +5,7 @@ import { EthereumAddress } from '../../../utils/EthereumAddress'
 import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
 import { bytes32ToAddress } from '../../utils/address'
 import { getCallResult } from '../../utils/getCallResult'
-import { getModules } from './GnosisSafe'
+import { getModules } from '../../utils/getSafeModules'
 
 const AVATAR_SLOT = Bytes.fromHex(
   '0x0000000000000000000000000000000000000000000000000000000000000066',
@@ -70,7 +70,7 @@ export async function detectGnosisSafeZodiacModule(
 
   return {
     implementations: [],
-    relatives: modules,
+    relatives: modules ?? [],
     upgradeability: {
       type: 'gnosis safe zodiac module',
       avatar,

--- a/packages/discovery/src/discovery/utils/getSafeModules.ts
+++ b/packages/discovery/src/discovery/utils/getSafeModules.ts
@@ -1,0 +1,37 @@
+import { EthereumAddress } from '../../utils/EthereumAddress'
+import { DiscoveryProvider } from '../provider/DiscoveryProvider'
+import { getCallResult } from './getCallResult'
+
+export async function getModules(
+  provider: DiscoveryProvider,
+  address: EthereumAddress,
+  blockNumber: number,
+): Promise<EthereumAddress[] | undefined> {
+  // Sentinel value used by Gnosis Safe to indicate the beginning and
+  // the end of the circular linked list.
+  // https://github.com/safe-global/safe-contracts/blob/52ce39c89cc3e3529963100dd774a6a03c098792/contracts/base/ModuleManager.sol#L23C35-L23C35
+  const SENTINEL_MODULES = '0x0000000000000000000000000000000000000001'
+  const PAGINATION_SIZE = 10
+
+  let next = SENTINEL_MODULES
+  const modules: EthereumAddress[] = []
+  do {
+    // Result: [modules[], next]
+    const result = await getCallResult<[string[], string]>(
+      provider,
+      address,
+      'function getModulesPaginated(address start, uint256 pageSize) view returns (address[] array, address next)',
+      [next, PAGINATION_SIZE],
+      blockNumber,
+      true,
+    )
+
+    if (result === undefined) {
+      return undefined
+    }
+
+    result[0].forEach((module) => modules.push(EthereumAddress(module)))
+    next = result[1]
+  } while (next !== SENTINEL_MODULES)
+  return modules
+}


### PR DESCRIPTION
Resolves L2B-3207

The old implementation has some false positives, for example in Zora it mistook some Proxy for a Zodiac Module. This is because the old mnemonic was

1. check two special storage slots
2. if there are not zero it's a zodiac module

The slots in question are 102 and 103. They are quite big but can interfere with some other contracts - like in the case of Zora.

The new mnemonic is the following

1. check two special storage slots
2. call a getter function for the guard
3. if slots are non zero and the getter for the guard did not revert it's a zodiac module

The unfortunate surprise is the fact that not all Zodiac based modules have to have a recursive module list. For example the Linea [Roles contract](https://etherscan.deth.net/address/0xF24f1DC519d88246809B660eb56D94048575d083#code) has that because it inherits from a `Modifier`. Meanwhile the [Optimistic Governor from AcrossV2](https://etherscan.deth.net/address/0x8692B776d1Ff0664177c90465038056Dc64f8991#code) only inherits from a contract one step below - from the `Module` contract. Now because of that the modules field in the zodiac module interface is optional.