### PR TITLE
Change etherscan client props' privacy scope

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.26.0
+
+### Minor Changes
+
+- Downgrade Etherscanlike Client's props privacy scope to enable easy class extension
+
 ## 0.25.1
 
 ### Patch Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/index.ts
+++ b/packages/discovery/src/index.ts
@@ -29,5 +29,9 @@ export {
   type InvertedAddresses,
 } from './inversion/runInversion'
 export { ChainId } from './utils/ChainId'
-export { EtherscanLikeClient } from './utils/EtherscanLikeClient'
+export {
+  EtherscanLikeClient,
+  tryParseEtherscanResponse,
+} from './utils/EtherscanLikeClient'
+export { getErrorMessage } from './utils/getErrorMessage'
 export { HttpClient } from './utils/HttpClient'

--- a/packages/discovery/src/utils/EtherscanLikeClient.ts
+++ b/packages/discovery/src/utils/EtherscanLikeClient.ts
@@ -19,18 +19,18 @@ export interface EtherscanUnsupportedMethods {
 }
 
 export class EtherscanLikeClient {
-  private readonly rateLimiter = new RateLimiter({
+  protected readonly rateLimiter = new RateLimiter({
     callsPerMinute: 150,
   })
-  private readonly timeoutMs = 20_000
+  protected readonly timeoutMs = 20_000
 
   constructor(
-    private readonly httpClient: HttpClient,
-    private readonly url: string,
-    private readonly apiKey: string,
-    private readonly minTimestamp: UnixTime,
-    private readonly unsupportedMethods: EtherscanUnsupportedMethods = {},
-    private readonly logger = Logger.SILENT,
+    protected readonly httpClient: HttpClient,
+    protected readonly url: string,
+    protected readonly apiKey: string,
+    protected readonly minTimestamp: UnixTime,
+    protected readonly unsupportedMethods: EtherscanUnsupportedMethods = {},
+    protected readonly logger = Logger.SILENT,
   ) {
     this.call = this.rateLimiter.wrap(this.call.bind(this))
   }
@@ -190,7 +190,7 @@ export class EtherscanLikeClient {
     return etherscanResponse.result
   }
 
-  private recordError(
+  protected recordError(
     module: string,
     action: string,
     timeMs: number,
@@ -200,7 +200,7 @@ export class EtherscanLikeClient {
   }
 }
 
-function tryParseEtherscanResponse(
+export function tryParseEtherscanResponse(
   text: string,
 ): EtherscanResponse | undefined {
   try {


### PR DESCRIPTION
## Context

Some platforms such as Routescan are almost fully-compatible with Etherscan-like API shape.
This modification enables us to extend Etherscanlike Client without rewriting it from scratch and altering only certain things.