### PR TITLE
Add testnets support to discovery

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.46.0
+
+### Minor Changes
+
+- Add sepolia support
+
 ## 0.45.5
 
 ### Patch Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.45.5",
+  "version": "0.46.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/config/chains.ts
+++ b/packages/discovery/src/config/chains.ts
@@ -81,4 +81,10 @@ export const chains: ChainConfig[] = [
     ),
     etherscanUrl: 'https://api-era.zksync.network/api',
   },
+
+  {
+    name: 'sepolia',
+    multicall: getMulticall3Config(751532),
+    etherscanUrl: 'https://api-sepolia.etherscan.io/api',
+  },
 ]

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -27,7 +27,8 @@
         "linea",
         "base",
         "polygonzkevm",
-        "gnosis"
+        "gnosis",
+        "sepolia"
       ]
     },
     "initialAddresses": {


### PR DESCRIPTION
It's sometimes useful to run discovery on the testnet. We need it in lz-monitoring to work on the v2 contracts.