### PR TITLE
Export getMulticall3Config from discovery

### DIFF
--- a/packages/discovery/src/discovery/provider/multicall/MulticallConfig.ts
+++ b/packages/discovery/src/discovery/provider/multicall/MulticallConfig.ts
@@ -18,16 +18,15 @@ export const multicallConfig = {
   polygon_zkevm: getMulticall3Config(57746),
 }
 
-function getMulticall3Config(
+export function getMulticall3Config(
   sinceBlock: number,
-  address: EthereumAddress = EthereumAddress(
-    '0xcA11bde05977b3631167028862bE2a173976CA11',
-  ),
+  address = EthereumAddress('0xcA11bde05977b3631167028862bE2a173976CA11'),
+  batchSize = 150,
 ): MulticallConfig {
   return {
     address,
     sinceBlock,
-    batchSize: 150,
+    batchSize,
     encodeBatch: encodeMulticall3,
     decodeBatch: decodeMulticall3,
   }

--- a/packages/discovery/src/index.ts
+++ b/packages/discovery/src/index.ts
@@ -20,7 +20,10 @@ export {
 export { toDiscoveryOutput } from './discovery/output/toDiscoveryOutput'
 export { DiscoveryProvider } from './discovery/provider/DiscoveryProvider'
 export { MulticallClient } from './discovery/provider/multicall/MulticallClient'
-export { multicallConfig } from './discovery/provider/multicall/MulticallConfig'
+export {
+  multicallConfig,
+  getMulticall3Config,
+} from './discovery/provider/multicall/MulticallConfig'
 export type { MulticallConfig } from './discovery/provider/multicall/types'
 export type { DiscoveryCache } from './discovery/provider/ProviderWithCache'
 export { ProviderWithCache } from './discovery/provider/ProviderWithCache'


### PR DESCRIPTION
This is required so that disovery users like the l2beat backend can create configurations for their own chains.