### PR TITLE
opDAHandler now doesn't check every tx of the last 10

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.39.1
+
+### Patch Changes
+
+- Don't check every tx in opDAHandler
+
 ## 0.39.0
 
 ### Minor Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/discovery/handlers/user/OpDAHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/OpDAHandler.ts
@@ -60,10 +60,6 @@ export class OpStackDAHandler implements ClassicHandler {
     const sequencerAddress = valueToAddress(resolved)
     const last10Txs = await provider.getLast10Txs(sequencerAddress, blockNumber)
 
-    const isAllTxsLengthEqualToCelestiaDAExample = last10Txs.every(
-      (tx) => tx.input.length === OP_STACK_CELESTIA_DA_EXAMPLE_INPUT.length,
-    )
-
     const isSomeTxsLengthEqualToCelestiaDAExample = last10Txs.some(
       (tx) => tx.input.length === OP_STACK_CELESTIA_DA_EXAMPLE_INPUT.length,
     )
@@ -71,7 +67,6 @@ export class OpStackDAHandler implements ClassicHandler {
     return {
       field: this.field,
       value: {
-        isAllTxsLengthEqualToCelestiaDAExample,
         isSomeTxsLengthEqualToCelestiaDAExample,
       },
     }


### PR DESCRIPTION
If the Celestia endpoint times out a given rollup will post to L1. This is non-deterministic and gives a lot of changes that are not important since it's possible that 1 transaction out of 10 will post to L1 and trigger a two changes: one change when it goes from `true->false` and the second when it goes to `false->true`.