### PR TITLE
Filter out incoming transactions from etherscan response

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.40.1
+
+### Patch Changes
+
+- Filter out incoming transactions from etherscan response
+
 ## 0.40.0
 
 ### Minor Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/discovery/handlers/user/OpDAHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/OpDAHandler.ts
@@ -58,7 +58,10 @@ export class OpStackDAHandler implements ClassicHandler {
       previousResults,
     )
     const sequencerAddress = valueToAddress(resolved)
-    const last10Txs = await provider.getLast10Txs(sequencerAddress, blockNumber)
+    const last10Txs = await provider.getLast10OutgoingTxs(
+      sequencerAddress,
+      blockNumber,
+    )
 
     const isSomeTxsLengthEqualToCelestiaDAExample = last10Txs.some(
       (tx) => tx.input.length === OP_STACK_CELESTIA_DA_EXAMPLE_INPUT.length,

--- a/packages/discovery/src/discovery/handlers/user/OpSequencerInboxHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/OpSequencerInboxHandler.ts
@@ -45,7 +45,10 @@ export class OpStackSequencerInboxHandler implements ClassicHandler {
     )
     const sequencerAddress = valueToAddress(resolved)
 
-    const last10Txs = await provider.getLast10Txs(sequencerAddress, blockNumber)
+    const last10Txs = await provider.getLast10OutgoingTxs(
+      sequencerAddress,
+      blockNumber,
+    )
 
     // check if all last 10 txs have the same to address
     const toAddress = last10Txs[0]?.to

--- a/packages/discovery/src/discovery/provider/DiscoveryProvider.ts
+++ b/packages/discovery/src/discovery/provider/DiscoveryProvider.ts
@@ -223,10 +223,10 @@ export class DiscoveryProvider {
     return this.etherscanLikeClient.getBlockNumberAtOrBefore(timestampNumber)
   }
 
-  async getLast10Txs(
+  async getLast10OutgoingTxs(
     address: EthereumAddress,
     toBlock: number,
-  ): ReturnType<EtherscanLikeClient['getLast10Txs']> {
-    return await this.etherscanLikeClient.getLast10Txs(address, toBlock)
+  ): ReturnType<EtherscanLikeClient['getLast10OutgoingTxs']> {
+    return await this.etherscanLikeClient.getLast10OutgoingTxs(address, toBlock)
   }
 }


### PR DESCRIPTION
The `txlist` method is also returning the incoming transactions, which is undesirable for us.