### PR TITLE
Log errors during discovery

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.42.0
+
+### Minor Changes
+
+- Log all the discovery errors at the end of the execution
+
 ## 0.41.0
 
 ### Minor Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/discovery/engine/DiscoveryEngine.ts
+++ b/packages/discovery/src/discovery/engine/DiscoveryEngine.ts
@@ -109,7 +109,8 @@ export class DiscoveryEngine {
   }
 
   private checkErrors(resolved: Analysis[]): void {
-    const errors = []
+    const errorMsgs = []
+    let errorCount = 0
     for (const analysis of resolved) {
       if (
         analysis.type === 'Contract' &&
@@ -121,12 +122,13 @@ export class DiscoveryEngine {
           ([field, error]) => `\n\t${field}: ${error}`,
         )
 
-        errors.push([msgStart, ...errorMessages, msgEnd].join(''))
+        errorCount += errorMessages.length
+        errorMsgs.push([msgStart, ...errorMessages, msgEnd].join(''))
       }
     }
-    if (errors.length > 0) {
-      this.logger.logError(`Errors during discovery: ${errors.length}`)
-      for (const error of errors) {
+    if (errorCount > 0) {
+      this.logger.logError(`Errors during discovery: ${errorCount}`)
+      for (const error of errorMsgs) {
         this.logger.logError(error)
       }
     }

--- a/packages/discovery/src/discovery/engine/DiscoveryEngine.ts
+++ b/packages/discovery/src/discovery/engine/DiscoveryEngine.ts
@@ -109,14 +109,26 @@ export class DiscoveryEngine {
   }
 
   private checkErrors(resolved: Analysis[]): void {
-    let errors = 0
+    const errors = []
     for (const analysis of resolved) {
-      if (analysis.type === 'Contract') {
-        errors += Object.keys(analysis.errors).length
+      if (
+        analysis.type === 'Contract' &&
+        Object.keys(analysis.errors).length > 0
+      ) {
+        const msgStart = `${analysis.name}(${analysis.address.toString()}): {`
+        const msgEnd = '\n}'
+        const errorMessages = Object.entries(analysis.errors).map(
+          ([field, error]) => `\n\t${field}: ${error}`,
+        )
+
+        errors.push([msgStart, ...errorMessages, msgEnd].join(''))
       }
     }
-    if (errors > 0) {
-      this.logger.logError(`Errors during discovery: ${errors}`)
+    if (errors.length > 0) {
+      this.logger.logError(`Errors during discovery: ${errors.length}`)
+      for (const error of errors) {
+        this.logger.logError(error)
+      }
     }
   }
 }


### PR DESCRIPTION
Because we sanitize the discovery output by hiding the error messages before sending it to the update monitor, there was no way to see what caused some errors. This PR adds log that will be visible in server logs. Moreover, when creating a new discovery, the user will have more information about the errors, directly in the terminal.
<img width="1341" alt="Screenshot 2024-02-13 at 13 42 34" src="https://github.com/l2beat/tools/assets/38423054/0a4e2fa8-759d-4c58-80a1-4df558fef35c">
