### PR TITLE
Export InvertedAddressDetails and Role types

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.42.1
+
+### Patch Changes
+
+- Export InvertedAddressDetails and Role types
+
 ## 0.42.0
 
 ### Minor Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/index.ts
+++ b/packages/discovery/src/index.ts
@@ -34,7 +34,9 @@ export { deduplicateAbi } from './discovery/source/deduplicateAbi'
 export { SourceCodeService } from './discovery/source/SourceCodeService'
 export {
   calculateInversion,
+  type InvertedAddressDetails,
   type InvertedAddresses,
+  type Role,
 } from './inversion/runInversion'
 export {
   EtherscanLikeClient,

--- a/packages/discovery/src/inversion/runInversion.ts
+++ b/packages/discovery/src/inversion/runInversion.ts
@@ -9,19 +9,19 @@ import { ConfigReader } from '../discovery/config/ConfigReader'
 import { DiscoveryConfig } from '../discovery/config/DiscoveryConfig'
 import { EthereumAddress } from '../utils/EthereumAddress'
 
-interface AddressDetails {
+export interface InvertedAddressDetails {
   name?: string
   address: string
   roles: Role[]
 }
 
-interface Role {
+export interface Role {
   name: string
   atName: string
   atAddress: EthereumAddress
 }
 
-export type InvertedAddresses = Map<string, AddressDetails>
+export type InvertedAddresses = Map<string, InvertedAddressDetails>
 
 export async function runInversion(
   project: string,
@@ -65,7 +65,7 @@ export function calculateInversion(
   discovery: DiscoveryOutput,
   config?: DiscoveryConfig,
 ): InvertedAddresses {
-  const addresses = new Map<string, AddressDetails>()
+  const addresses = new Map<string, InvertedAddressDetails>()
 
   function add(address: ContractValue, role?: Role): void {
     if (
@@ -156,7 +156,7 @@ export function calculateInversion(
   return addresses
 }
 
-function print(addresses: Map<string, AddressDetails>): void {
+function print(addresses: Map<string, InvertedAddressDetails>): void {
   for (const details of addresses.values()) {
     const name = details.name
       ? chalk.blue(details.name)
@@ -175,7 +175,7 @@ function print(addresses: Map<string, AddressDetails>): void {
   }
 }
 
-function createMermaid(addresses: Map<string, AddressDetails>): string {
+function createMermaid(addresses: Map<string, InvertedAddressDetails>): string {
   const rows: string[] = ['flowchart LR']
   for (const details of addresses.values()) {
     if (details.roles.length === 0) {


### PR DESCRIPTION
Two additional types need to be exported from discovery for l2beat templates.

I've renamed `AddressDetails` type to `InvertedAddressDetails` to make it more explicit where it is used.