### PR TITLE
Support all uint types in Array Handler

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.42.2
+
+### Patch Changes
+
+- Support all uint types in ArrayHandler
+
 ## 0.42.1
 
 ### Patch Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.42.1",
+  "version": "0.42.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/discovery/handlers/user/ArrayHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/ArrayHandler.ts
@@ -20,6 +20,7 @@ export const ArrayHandlerDefinition = z.strictObject({
   maxLength: z.optional(z.number().int().nonnegative()),
   startIndex: z.optional(z.number().int().nonnegative()),
   ignoreRelative: z.optional(z.boolean()),
+  returnTupleIndices: z.optional(z.array(z.number())),
 })
 
 const DEFAULT_MAX_LENGTH = 100
@@ -190,7 +191,8 @@ function isArrayFragment(fragment: utils.FunctionFragment): boolean {
     (fragment.stateMutability === 'view' ||
       fragment.stateMutability === 'pure') &&
     fragment.inputs.length === 1 &&
-    (fragment.inputs[0]?.type === 'uint256' ||
-      fragment.inputs[0]?.type === 'uint16')
+    ['uint16', 'uint32', 'uint64', 'uint256'].includes(
+      fragment.inputs[0]?.type ?? '',
+    )
   )
 }

--- a/packages/discovery/src/discovery/handlers/user/ArrayHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/ArrayHandler.ts
@@ -20,7 +20,6 @@ export const ArrayHandlerDefinition = z.strictObject({
   maxLength: z.optional(z.number().int().nonnegative()),
   startIndex: z.optional(z.number().int().nonnegative()),
   ignoreRelative: z.optional(z.boolean()),
-  returnTupleIndices: z.optional(z.array(z.number())),
 })
 
 const DEFAULT_MAX_LENGTH = 100


### PR DESCRIPTION
Previously only uint256 and uint16 were support, probably by mistake.