### PR TITLE
Fix an edge case in saving flattened source files

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.43.6
+
+### Patch Changes
+
+- Fix edge case in saving flattened sources
+
 ## 0.43.5
 
 ### Patch Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.43.5",
+  "version": "0.43.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/discovery/output/saveDiscoveryResult.ts
+++ b/packages/discovery/src/discovery/output/saveDiscoveryResult.ts
@@ -122,7 +122,7 @@ async function saveFlatSources(
   const flatSourcesFolder = `.flat${options.sourcesFolder ?? ''}`
   const flatSourcesPath = posix.join(rootPath, flatSourcesFolder)
   const allContractNames = results.map((c) =>
-    c.type !== 'EOA' ? c.name : 'EOA',
+    c.type !== 'EOA' ? (c.derivedName ?? c.name) : 'EOA',
   )
 
   await rimraf(flatSourcesPath)

--- a/packages/discovery/src/discovery/output/saveDiscoveryResult.ts
+++ b/packages/discovery/src/discovery/output/saveDiscoveryResult.ts
@@ -122,7 +122,7 @@ async function saveFlatSources(
   const flatSourcesFolder = `.flat${options.sourcesFolder ?? ''}`
   const flatSourcesPath = posix.join(rootPath, flatSourcesFolder)
   const allContractNames = results.map((c) =>
-    c.type !== 'EOA' ? (c.derivedName ?? c.name) : 'EOA',
+    c.type !== 'EOA' ? c.derivedName ?? c.name : 'EOA',
   )
 
   await rimraf(flatSourcesPath)


### PR DESCRIPTION
Fix an edge case in saving flattened source files

Suppose there are two contracts in a project. Both named "ContractA". If
we override the name of contract `#1` with "ContractB" its name is
going to be "ContractB" but its derived name is going to be equal to
"ContractA". SourceCodeService while generating sources does not reach
into overrides so the source name is always going to be the
"derivedName". We should always choose the derived name (if present, if
it's not, the name is equal to the derived name).

The edge case we've hit is that in the above example, while checking for
contract clashes we had an array that looked like `[ContractA,
ContractB]` instead of `[ContractA, ContractA]`.