### PR TITLE
Add --flat-sources-folder cli flag

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.43.7
+
+### Patch Changes
+
+- Add --flat-sources-folder as cli parameter
+
 ## 0.43.6
 
 ### Patch Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.43.6",
+  "version": "0.43.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/cli/discoverCommand.ts
+++ b/packages/discovery/src/cli/discoverCommand.ts
@@ -69,6 +69,7 @@ export function discover(
     dryRun: config.dryRun === true,
     dev: config.dev === true,
     sourcesFolder: config.sourcesFolder,
+    flatSourcesFolder: config.flatSourcesFolder,
     discoveryFilename: config.discoveryFilename,
     blockNumber: config.blockNumber,
   })

--- a/packages/discovery/src/cli/getCliParameters.test.ts
+++ b/packages/discovery/src/cli/getCliParameters.test.ts
@@ -37,6 +37,7 @@ describe(getCliParameters.name, () => {
       dryRun: false,
       dev: false,
       sourcesFolder: undefined,
+      flatSourcesFolder: undefined,
       discoveryFilename: undefined,
       blockNumber: undefined,
     })
@@ -51,6 +52,7 @@ describe(getCliParameters.name, () => {
       dryRun: true,
       dev: false,
       sourcesFolder: undefined,
+      flatSourcesFolder: undefined,
       discoveryFilename: undefined,
       blockNumber: undefined,
     })
@@ -72,7 +74,29 @@ describe(getCliParameters.name, () => {
       dryRun: false,
       dev: true,
       sourcesFolder: '.code@1234',
+      flatSourcesFolder: undefined,
       discoveryFilename: 'discovery@1234',
+      blockNumber: undefined,
+    })
+  })
+
+  it('discover ethereum foo --flat-sources-folder=.flat@1234 --sources-folder=.code@1234', () => {
+    const cli = getCliParameters([
+      'discover',
+      'ethereum',
+      'foo',
+      '--flat-sources-folder=.flat@1234',
+      '--sources-folder=.code@1234',
+    ])
+    expect(cli).toEqual({
+      mode: 'discover',
+      chain: 'ethereum',
+      project: 'foo',
+      dryRun: false,
+      dev: false,
+      sourcesFolder: '.code@1234',
+      flatSourcesFolder: '.flat@1234',
+      discoveryFilename: undefined,
       blockNumber: undefined,
     })
   })
@@ -102,6 +126,7 @@ describe(getCliParameters.name, () => {
       dryRun: true,
       dev: false,
       sourcesFolder: undefined,
+      flatSourcesFolder: undefined,
       discoveryFilename: undefined,
       blockNumber: 5678,
     })

--- a/packages/discovery/src/cli/getCliParameters.ts
+++ b/packages/discovery/src/cli/getCliParameters.ts
@@ -22,6 +22,7 @@ export interface DiscoverCliParameters {
   dryRun: boolean
   dev: boolean
   sourcesFolder?: string
+  flatSourcesFolder?: string
   discoveryFilename?: string
   blockNumber?: number
 }
@@ -73,6 +74,7 @@ export function getCliParameters(args = process.argv.slice(2)): CliParameters {
     let dev = false
     let blockNumber: number | undefined
     let sourcesFolder: string | undefined
+    let flatSourcesFolder: string | undefined
     let discoveryFilename: string | undefined
 
     if (remaining.includes('--dry-run')) {
@@ -101,6 +103,14 @@ export function getCliParameters(args = process.argv.slice(2)): CliParameters {
     const sourcesFolderArg = extractArgWithValue(remaining, '--sources-folder')
     if (sourcesFolderArg.found) {
       sourcesFolder = sourcesFolderArg.value
+    }
+
+    const flatSourcesFolderArg = extractArgWithValue(
+      remaining,
+      '--flat-sources-folder',
+    )
+    if (flatSourcesFolderArg.found) {
+      flatSourcesFolder = flatSourcesFolderArg.value
     }
 
     const discoveryFilenameArg = extractArgWithValue(
@@ -136,6 +146,7 @@ export function getCliParameters(args = process.argv.slice(2)): CliParameters {
       dryRun,
       dev,
       sourcesFolder,
+      flatSourcesFolder,
       discoveryFilename,
       blockNumber,
     }

--- a/packages/discovery/src/config/config.discovery.ts
+++ b/packages/discovery/src/config/config.discovery.ts
@@ -35,6 +35,7 @@ export function getDiscoveryCliConfig(cli: CliParameters): DiscoveryCliConfig {
       dev: cli.dev,
       blockNumber: cli.blockNumber,
       sourcesFolder: cli.sourcesFolder,
+      flatSourcesFolder: cli.flatSourcesFolder,
       discoveryFilename: cli.discoveryFilename,
     },
     singleDiscovery: singleDiscoveryEnabled && {

--- a/packages/discovery/src/config/types.ts
+++ b/packages/discovery/src/config/types.ts
@@ -16,6 +16,7 @@ export interface DiscoveryModuleConfig {
   readonly dev?: boolean
   readonly blockNumber?: number
   readonly sourcesFolder?: string
+  readonly flatSourcesFolder?: string
   readonly discoveryFilename?: string
 }
 

--- a/packages/discovery/src/discovery/output/saveDiscoveryResult.ts
+++ b/packages/discovery/src/discovery/output/saveDiscoveryResult.ts
@@ -24,6 +24,7 @@ import { toPrettyJson } from './toPrettyJson'
 export interface SaveDiscoveryResultOptions {
   rootFolder?: string
   sourcesFolder?: string
+  flatSourcesFolder?: string
   discoveryFilename?: string
   metaFilename?: string
 }
@@ -119,7 +120,7 @@ async function saveFlatSources(
   logger: DiscoveryLogger,
   options: SaveDiscoveryResultOptions,
 ): Promise<void> {
-  const flatSourcesFolder = `.flat${options.sourcesFolder ?? ''}`
+  const flatSourcesFolder = options.flatSourcesFolder ?? '.flat'
   const flatSourcesPath = posix.join(rootPath, flatSourcesFolder)
   const allContractNames = results.map((c) =>
     c.type !== 'EOA' ? c.derivedName ?? c.name : 'EOA',

--- a/packages/discovery/src/discovery/runDiscovery.ts
+++ b/packages/discovery/src/discovery/runDiscovery.ts
@@ -60,6 +60,7 @@ export async function runDiscovery(
     logger,
     {
       sourcesFolder: config.sourcesFolder,
+      flatSourcesFolder: config.flatSourcesFolder,
       discoveryFilename: config.discoveryFilename,
     },
   )


### PR DESCRIPTION
Resolves this suggestion by Peter

> So my understanding after reading this is that this option allows you to save output to a different folder than .code. I am not even sure how useful it is because it resolves relative to the discovered files and so it will still be in {projectName}/{chainName} right? Anyway, I don't feel like having sources outputted to foo and .flatfoo is what users would want. I feel like foo/.code and foo/.flat seem more desirable. Or provide two flags --code-folder and --flat-folder.