### PR TITLE
Allow for n-darray

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.44.1
+
+### Patch Changes
+
+- Allow for n-darray in normalizeDiffPath
+
 ## 0.44.0
 
 ### Minor Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/discovery/utils/normalizeDiffPath.test.ts
+++ b/packages/discovery/src/discovery/utils/normalizeDiffPath.test.ts
@@ -15,21 +15,25 @@ describe(normalizeDiffPath.name, () => {
     expect(normalizeDiffPath('test')).toEqual('test')
   })
 
-  it('should remove array suffix and values.prefix', () => {
+  it('remove array suffix and prefixes', () => {
     expect(normalizeDiffPath('values.test.0')).toEqual('test')
     expect(normalizeDiffPath('values.test.1')).toEqual('test')
     expect(normalizeDiffPath('values.test.12')).toEqual('test')
     expect(normalizeDiffPath('values.test.01')).toEqual('test')
     expect(normalizeDiffPath('values.test.21')).toEqual('test')
+    expect(normalizeDiffPath('values.test.0.1')).toEqual('test')
+    expect(normalizeDiffPath('values.test.2.1.0')).toEqual('test')
 
     expect(normalizeDiffPath('upgradeability.test.0')).toEqual('test')
     expect(normalizeDiffPath('upgradeability.test.1')).toEqual('test')
     expect(normalizeDiffPath('upgradeability.test.12')).toEqual('test')
     expect(normalizeDiffPath('upgradeability.test.01')).toEqual('test')
     expect(normalizeDiffPath('upgradeability.test.21')).toEqual('test')
+    expect(normalizeDiffPath('upgradeability.test.0.1')).toEqual('test')
+    expect(normalizeDiffPath('upgradeability.test.2.1.0')).toEqual('test')
   })
 
-  it('should remove array suffix when no values. prefix', () => {
+  it('remove array suffix when no values. prefix', () => {
     expect(normalizeDiffPath('test.0')).toEqual('test')
     expect(normalizeDiffPath('test.1')).toEqual('test')
     expect(normalizeDiffPath('test.12')).toEqual('test')
@@ -39,18 +43,25 @@ describe(normalizeDiffPath.name, () => {
 
   it('should throw on different prefix', () => {
     expect(() => normalizeDiffPath('test.values.0')).toThrow(
-      'Expected test.values.0 to have only one suffix',
+      'Expected test.values.0 to have only numeric suffixes',
     )
   })
 })
 
 describe(removeArraySuffix.name, () => {
-  it('should remove the array suffix', () => {
+  it('remove single array suffix', () => {
     expect(removeArraySuffix('test.0')).toEqual('test')
     expect(removeArraySuffix('test.1')).toEqual('test')
     expect(removeArraySuffix('test.12')).toEqual('test')
     expect(removeArraySuffix('test.01')).toEqual('test')
     expect(removeArraySuffix('test.21')).toEqual('test')
+  })
+
+  it('remove multiple array suffixes', () => {
+    expect(removeArraySuffix('test.0.0')).toEqual('test')
+    expect(removeArraySuffix('test.0.6')).toEqual('test')
+    expect(removeArraySuffix('test.0.6.0')).toEqual('test')
+    expect(removeArraySuffix('test.1.2.3.4.5.6.7')).toEqual('test')
   })
 
   it('should return the input if it does not contain a suffix', () => {
@@ -59,19 +70,16 @@ describe(removeArraySuffix.name, () => {
 
   it('should throw if the suffix is not a decimal number', () => {
     expect(() => removeArraySuffix('test.a')).toThrow(
-      'Expected a to be a number',
+      'Expected test.a to have only numeric suffixes',
     )
     expect(() => removeArraySuffix('test.1a')).toThrow(
-      'Expected 1a to be a number',
+      'Expected test.1a to have only numeric suffixes',
     )
     expect(() => removeArraySuffix('test.1e2')).toThrow(
-      'Expected 1e2 to be a number',
+      'Expected test.1e2 to have only numeric suffixes',
     )
-  })
-
-  it('should throw if the input has more than one suffix', () => {
-    expect(() => removeArraySuffix('test.1.2')).toThrow(
-      'Expected test.1.2 to have only one suffix',
+    expect(() => removeArraySuffix('test.0.')).toThrow(
+      'Expected test.0. to have only numeric suffixes',
     )
   })
 })

--- a/packages/discovery/src/discovery/utils/normalizeDiffPath.ts
+++ b/packages/discovery/src/discovery/utils/normalizeDiffPath.ts
@@ -19,12 +19,9 @@ export function removeArraySuffix(path: string): string {
   if (path.includes('.')) {
     const [name, ...rest] = path.split('.')
 
-    assert(rest.length === 1, `Expected ${path} to have only one suffix`)
-    assert(
-      name !== undefined && rest[0] !== undefined,
-      `Unexpected undefined value`,
-    )
-    assert(isIntNumeric(rest[0]), `Expected ${rest[0]} to be a number`)
+    assert(rest.length >= 1, `Unreachable code`)
+    assert( name !== undefined, `Unexpected undefined value`)
+    assert(rest.every(p => p.length > 0 && isIntNumeric(p)), `Expected ${path} to have only numeric suffixes`)
     return name
   }
 

--- a/packages/discovery/src/discovery/utils/normalizeDiffPath.ts
+++ b/packages/discovery/src/discovery/utils/normalizeDiffPath.ts
@@ -20,8 +20,11 @@ export function removeArraySuffix(path: string): string {
     const [name, ...rest] = path.split('.')
 
     assert(rest.length >= 1, `Unreachable code`)
-    assert( name !== undefined, `Unexpected undefined value`)
-    assert(rest.every(p => p.length > 0 && isIntNumeric(p)), `Expected ${path} to have only numeric suffixes`)
+    assert(name !== undefined, `Unexpected undefined value`)
+    assert(
+      rest.every((p) => p.length > 0 && isIntNumeric(p)),
+      `Expected ${path} to have only numeric suffixes`,
+    )
     return name
   }
 


### PR DESCRIPTION
Example update-monitor message that includes 2d-array

```diff
      values.getProviderInfoAt.0.6:
-        -192
+        -833
```
```diff
      values.getProviderInfoAt.0.5:
-        "535639074270563789506100"
+        "590078921054041246414598"
```
```diff
      values.getProviderInfoAt.0.4:
-        "535639074270563789506292"
+        "590078921054041246415431"
```
```diff
      values.getProviderInfoAt.0.2:
-        "535639074270563789506100"
+        "590078921054041246414598"
```