### PR TITLE
Update ArbitrumDACKeysetHandler to use more descriptive variable names

### DIFF
--- a/packages/discovery/src/discovery/handlers/user/ArbitrumDACKeysetHandler.test.ts
+++ b/packages/discovery/src/discovery/handlers/user/ArbitrumDACKeysetHandler.test.ts
@@ -55,8 +55,8 @@ describe(ArbitrumDACKeysetHandler.name, () => {
     expect(value).toEqual({
       field: 'someName',
       value: {
-        threshold: 4,
-        keyCount: 7,
+        requiredSignatures: 4,
+        membersCount: 7,
       },
     })
   })
@@ -83,8 +83,8 @@ describe(ArbitrumDACKeysetHandler.name, () => {
     expect(value).toEqual({
       field: 'someName',
       value: {
-        threshold: 0,
-        keyCount: 0,
+        requiredSignatures: 0,
+        membersCount: 0,
       },
     })
   })

--- a/packages/discovery/src/discovery/handlers/user/ArbitrumDACKeysetHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/ArbitrumDACKeysetHandler.ts
@@ -43,26 +43,26 @@ export class ArbitrumDACKeysetHandler implements ClassicHandler {
       blockNumber,
     )
 
-    const { threshold, keyCount } = decodeLastEvent(events)
+    const { requiredSignatures, membersCount } = decodeLastEvent(events)
 
     return {
       field: this.field,
       value: {
-        threshold: threshold,
-        keyCount: keyCount,
+        requiredSignatures,
+        membersCount,
       },
     }
   }
 }
 
 function decodeLastEvent(events: providers.Log[]): {
-  threshold: number
-  keyCount: number
+  requiredSignatures: number
+  membersCount: number
 } {
   if (events.length === 0) {
     return {
-      threshold: 0,
-      keyCount: 0,
+      requiredSignatures: 0,
+      membersCount: 0,
     }
   }
 
@@ -72,11 +72,13 @@ function decodeLastEvent(events: providers.Log[]): {
 
   // NOTE(radomski): Schema is not public, but we know that the first 8 bytes are the threshold and the next 8 are the keyCount
   const keysetBytes = Bytes.fromHex(decodedEvent.keysetBytes as string)
-  const threshold = keysetBytes.slice(0, 8).toNumber()
-  const keyCount = keysetBytes.slice(8, 16).toNumber()
+  const assummedHonestMembers = keysetBytes.slice(0, 8).toNumber()
+  const membersCount = keysetBytes.slice(8, 16).toNumber()
+
+  const requiredSignatures = membersCount - assummedHonestMembers + 1
 
   return {
-    threshold,
-    keyCount,
+    requiredSignatures,
+    membersCount,
   }
 }


### PR DESCRIPTION
This pull request updates the ArbitrumDACKeysetHandler class to use more descriptive variable names for clarity and readability. The variable names `threshold` and `keyCount` have been changed to `requiredSignatures` and `membersCount` respectively. Previously the names were incorrect as `threshold` was actually `assumedHonestMembers` and `threshold=keyCount-assumedHonestMembers+1`.