### PR TITLE
Make the array syntax consistent

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.45.3
+
+### Patch Changes
+
+- Make the array syntax consistent
+
 ## 0.45.2
 
 ### Patch Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.45.2",
+  "version": "0.45.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/discovery/output/diffContracts.test.ts
+++ b/packages/discovery/src/discovery/output/diffContracts.test.ts
@@ -62,7 +62,7 @@ describe(diffContracts.name, () => {
       },
       { key: 'values.A', before: 'true', after: 'false' },
       { key: 'values.B', before: 'true' },
-      { key: 'values.D[3]', after: '4' },
+      { key: 'values.D.3', after: '4' },
     ])
   })
 })

--- a/packages/discovery/src/discovery/output/diffContracts.ts
+++ b/packages/discovery/src/discovery/output/diffContracts.ts
@@ -44,9 +44,9 @@ export function diffContracts(
       case 'A':
         {
           const r: FieldDiff = {
-            key: `${difference.path?.join('.') ?? 'undefined'}[${
+            key: `${difference.path?.join('.') ?? 'undefined'}.${
               difference.index
-            }]`,
+            }`,
           }
           if (difference.item.kind === 'N') {
             r.after = JSON.stringify(difference.item.rhs)


### PR DESCRIPTION
Resolves L2B-4365

# Description

In all other places we use `.{index}` syntax to flatten array elements.
Having a single place where we do `[{index}]` messes up the meta.json
description generation. See the Discord message described in the linked
Linear issue to see an example.
