### PR TITLE
Pull reorgSafeDepth (for discovery cache) from env

### DIFF
--- a/packages/discovery/CHANGELOG.md
+++ b/packages/discovery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @l2beat/discovery
 
+## 0.46.10
+
+### Patch Changes
+
+- Read reorgSafeDepth from environment variable
+
 ## 0.46.9
 
 ### Patch Changes

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@l2beat/discovery",
   "description": "L2Beat discovery - engine & tooling utilized for keeping an eye on L2s",
-  "version": "0.46.9",
+  "version": "0.46.10",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/discovery/src/config/config.discovery.ts
+++ b/packages/discovery/src/config/config.discovery.ts
@@ -72,6 +72,10 @@ export function getChainConfig(chain: string): DiscoveryChainConfig {
       //support for legacy local configs
       `DISCOVERY_${ENV_NAME}_RPC_GETLOGS_MAX_RANGE`,
     ]),
+    reorgSafeDepth: env.optionalInteger([
+      `${ENV_NAME}_REORG_SAFE_DEPTH_FOR_DISCOVERY`,
+      `${ENV_NAME}_REORG_SAFE_DEPTH`,
+    ]),
     multicall: chainConfig.multicall,
     etherscanApiKey: env.string([
       `${ENV_NAME}_ETHERSCAN_API_KEY_FOR_DISCOVERY`,

--- a/packages/discovery/src/config/types.ts
+++ b/packages/discovery/src/config/types.ts
@@ -29,6 +29,7 @@ export interface DiscoveryChainConfig {
   name: string
   rpcUrl: string
   rpcGetLogsMaxRange?: number
+  reorgSafeDepth?: number
   multicall: MulticallConfig
   etherscanApiKey: string
   etherscanUrl: string

--- a/packages/discovery/src/discovery/runDiscovery.ts
+++ b/packages/discovery/src/discovery/runDiscovery.ts
@@ -149,6 +149,7 @@ export async function discover(
   logger: DiscoveryLogger,
   blockNumber: number,
   getLogsMaxRange?: number,
+  reorgSafeDepth?: number,
 ): Promise<Analysis[]> {
   const sqliteCache = new SQLiteCache()
   await sqliteCache.init()
@@ -160,6 +161,7 @@ export async function discover(
     config.chain,
     sqliteCache,
     getLogsMaxRange,
+    reorgSafeDepth,
   )
 
   const proxyDetector = new ProxyDetector(discoveryProvider, logger)


### PR DESCRIPTION
I've noticed there is no way to configure it, so I'm adding env variable for it.

I think it was there before (I see it in my local .env) but has been probably refactored out somehow.